### PR TITLE
Get attendee information from registration + add the ability to create tags

### DIFF
--- a/api.graphql
+++ b/api.graphql
@@ -10,6 +10,8 @@ type Mutation {
   check_in(user: ID!, tag: String!): UserAndTags
   # Check-out a user by specifying the tag name
   check_out(user: ID!, tag: String!): UserAndTags
+  # Add tag to all users
+  add_tag(tag: String!): Tag
 }
 
 # The root query type, use to query data

--- a/api.graphql
+++ b/api.graphql
@@ -59,6 +59,10 @@ type Tag {
 type TagState {
   tag: Tag!
   checked_in: Boolean!
+  # Date when the attendee was checked in
+  checked_in_date: String
+  # The username of the admin that checked the attendee in
+  checked_in_by: String
 }
 
 # NOTE: Type names that forward to registration must match the type names

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$SOURCE_DIR")" || exit
 set -xeuo pipefail
 
 # Load Registration's API
-curl -s 'https://raw.githubusercontent.com/HackGT/registration/7901e18c3fbedfe4dd81b04067efe7300f9fd9a8/api.graphql' \
+curl -s 'https://raw.githubusercontent.com/HackGT/registration/master/api.graphql' \
      > ./apis/registration.graphql
 
 ./node_modules/.bin/apollo-codegen introspect-schema \

--- a/client/default.css
+++ b/client/default.css
@@ -171,14 +171,11 @@ button#add-new-tag {
 	width: initial;
 	margin-top: 10px;
 }
-#question-options-wrapper span i {
+.collapsible span i {
 	vertical-align: middle;
 }
-#question-options-wrapper span {
+.collapsible span  {
 	cursor: pointer;
-}
-button#update-question-options {
-	display: block;
 }
 div#additional-info {
 	font-style: italic;
@@ -191,6 +188,7 @@ div#additional-info {
 #question-options {
 	display: flex;
 	flex-wrap: wrap;
+	justify-content: center;
 }
 #question-options .mdc-form-field {
 	width: 33%;
@@ -200,4 +198,11 @@ div#additional-info {
 	flex-wrap: wrap;
 	min-height: 72px;
 	height: auto;
+}
+div#filters {
+	text-align: center;
+}
+div#button-row {
+	flex: 0 1 100%;
+	text-align: center;
 }

--- a/client/default.css
+++ b/client/default.css
@@ -163,8 +163,41 @@ abbr {
 	li.mdc-list-item > .actions > span:empty {
 		display: none;
 	}
+	#question-options .mdc-form-field {
+		width: 100% !important;
+	}
 }
 button#add-new-tag {
 	width: initial;
 	margin-top: 10px;
+}
+#question-options-wrapper span i {
+	vertical-align: middle;
+}
+#question-options-wrapper span {
+	cursor: pointer;
+}
+button#update-question-options {
+	display: block;
+}
+div#additional-info {
+	font-style: italic;
+	font-size: .875em;
+	line-height: 1.2em;
+	flex: 0 1 100%;
+	margin-left: 4em;
+	margin-bottom: .5em;
+}
+#question-options {
+	display: flex;
+	flex-wrap: wrap;
+}
+#question-options .mdc-form-field {
+	width: 33%;
+	box-sizing: border-box;
+}
+#attendees > .mdc-list-item {
+	flex-wrap: wrap;
+	min-height: 72px;
+	height: auto;
 }

--- a/client/index.html
+++ b/client/index.html
@@ -225,22 +225,10 @@
 					<div class="card-content">
 						<section class="center">
 							<h1 class="mdc-typography--headline">Add Tags</h1>
-							<p>Add tags to groups of attendees</p>
 							<div class="mdc-textfield" data-mdc-auto-init="MDCTextfield">
-								<input class="mdc-textfield__input" type="text" id="new-tag-name" list="autocomplete-tags">
-								<datalist id="autocomplete-tags">
-									{{#each tags}}
-										<option value="{{this}}"></option>
-									{{/each}}
-								</datalist>
-								<label class="mdc-textfield__label" for="new-tag-name">Tag</label>
+								<input class="mdc-textfield__input" type="text" id="new-tag-name">
+								<label class="mdc-textfield__label" for="new-tag-name">Tag Name</label>
 							</div>
-							<select class="mdc-select" id="current-tag" role="listbox">
-								<option selected disabled hidden>Select attendees</option>
-							    {{#each tags}}
-							    	<option value="{{this}}">Attendees with {{this}} tag</option>
-							    {{/each}}
-							</select>
 							<button class="mdc-button mdc-button--primary mdc-ripple-surface mdc-button--raised" data-mdc-auto-init="MDCRipple" id="add-new-tag">Add</button>
 						</section>
 					</div>

--- a/client/index.html
+++ b/client/index.html
@@ -88,12 +88,28 @@
 								<option value="false">Non checked in attendees</option>
 							</select>
 							<em id="loading-status">Loading...</em>
-							<div id="question-options-wrapper">
+							<div id="question-options-wrapper" class="collapsible">
 								<span><i class="material-icons">keyboard_arrow_down</i>Registration Questions</span>
 								<div id="question-options" style="display:none;">
-									<button class="mdc-button mdc-button--primary mdc-ripple-surface mdc-button--raised" data-mdc-auto-init="MDCRipple" id="update-question-options">
-										Update
-									</button>
+									<div id="button-row">
+										<button class="mdc-button mdc-button--primary mdc-ripple-surface mdc-button--raised" data-mdc-auto-init="MDCRipple" id="update-question-options">
+											Update
+										</button>
+									</div>
+								</div>
+							</div>
+							<div id="filters-wrapper" class="collapsible">
+								<span><i class="material-icons">keyboard_arrow_down</i>Registration Filters</span>
+								<div id="filters" style="display: none;">
+									<select class="mdc-select" style="width: 300px;" id="attending-filter">
+										<option value="">All users</option>
+										<option value="applied">Applied</option>
+										<option value="accepted">Accepted</option>
+										<option value="attending" default selected>Attending</option>
+									</select>
+									<select class="mdc-select" style="width: 300px;" id="branches-filter">
+										<option value="">All application branches</option>
+									</select>
 								</div>
 							</div>
 						</section>

--- a/client/index.html
+++ b/client/index.html
@@ -88,6 +88,14 @@
 								<option value="false">Non checked in attendees</option>
 							</select>
 							<em id="loading-status">Loading...</em>
+							<div id="question-options-wrapper">
+								<span><i class="material-icons">keyboard_arrow_down</i>Registration Questions</span>
+								<div id="question-options" style="display:none;">
+									<button class="mdc-button mdc-button--primary mdc-ripple-surface mdc-button--raised" data-mdc-auto-init="MDCRipple" id="update-question-options">
+										Update
+									</button>
+								</div>
+							</div>
 						</section>
 
 						<ul class="mdc-list mdc-list--two-line" id="attendees"></ul>
@@ -236,9 +244,30 @@
 						Check in
 					</button>
 				</div>
+				<div id="additional-info"></div>
 			</li>
 		</template>
+		<template id="checkbox-item">
+			<div class="mdc-form-field">
+			  <div class="mdc-checkbox">
+			    <input type="checkbox"
+			           id="my-checkbox"
+			           class="mdc-checkbox__native-control"/>
+			    <div class="mdc-checkbox__background">
+			      <svg class="mdc-checkbox__checkmark"
+			           viewBox="0 0 24 24">
+			        <path class="mdc-checkbox__checkmark__path"
+			              fill="none"
+			              stroke="white"
+			              d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+			      </svg>
+			      <div class="mdc-checkbox__mixedmark"></div>
+			    </div>
+			  </div>
 
+			  <label for="my-checkbox">Label</label>
+			</div>
+		</template>
 		<script src="/node_modules/material-components-web/dist/material-components-web.js"></script>
 		<script src="/js/main.js"></script>
 	</body>

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -506,7 +506,6 @@ document.getElementById("add-new-tag")!.addEventListener("click", e => {
 		return;
 	}
 
-	console.log(tag);
 	qwest.post(`/graphql`, JSON.stringify({
 		query: `mutation {
 			add_tag(tag: "${tag}") {
@@ -517,6 +516,7 @@ document.getElementById("add-new-tag")!.addEventListener("click", e => {
 		// Add to tag selectors
 		updateTagSelectors([tag]);
 		
+		// Clear form
 		tagInput.value = "";
 		document.querySelector(`label[for="new-tag-name"]`)!.classList.remove("mdc-textfield__label--float-above");
 		

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -109,6 +109,12 @@ interface ISearchUserResponse {
 	}
 }
 
+interface IUpdatedAttendee {
+	id: string;
+	tag: string;
+	checked_in: boolean;
+}
+
 function delay (milliseconds: number) {
 	return new Promise<void>(resolve => {
 		setTimeout(resolve, milliseconds);
@@ -502,30 +508,29 @@ function startWebSocketListener() {
 			return;
 
 		let tag: string = tagSelector.value;
-		let attendee: IAttendee = JSON.parse(event.data);
-		console.log(attendee);
+		let attendee: IUpdatedAttendee = JSON.parse(event.data);
+
 		let button = <HTMLButtonElement> document.querySelector(`#item-${attendee.id} > .actions > button`);
 		if (!button) {
 			// This attendee belongs to a tag that isn't currently being shown
 			// This message can safely be ignored; the user list will be updated when switching tags
 			return;
 		}
-		if (tag !== attendee.updatedTag) {
+		if (tag !== attendee.tag) {
 			// Check if the currently displayed tag is the tag that was just updated
 			return;
 		}
-		let status = <HTMLSpanElement> document.querySelector(`#${button.parentElement!.parentElement!.id} > .actions > span.status`)!;
+		// let status = <HTMLSpanElement> document.querySelector(`#${button.parentElement!.parentElement!.id} > .actions > span.status`)!;
 
-		let date = attendee.tags[tag].checked_in_date;
-		if (date) {
+		if (attendee.checked_in) {
 			button.textContent = "Uncheck in";
 			button.classList.add("checked-in");
-			status.innerHTML = statusFormatter(date, attendee.tags[tag].checked_in_by);
+			// status.innerHTML = statusFormatter(date, attendee.tags[tag].checked_in_by);
 		}
 		else {
 			button.textContent = "Check in";
 			button.classList.remove("checked-in");
-			status.textContent = "";
+			// status.textContent = "";
 		}
 	});
 	socket.addEventListener("error", (event) => {

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -113,7 +113,7 @@ interface IGraphqlAttendee {
 
 interface ISearchUserResponse {
 	data: {
-		search_user: IGraphqlAttendee[]
+		search_user_simple: IGraphqlAttendee[]
 	}
 }
 
@@ -284,7 +284,7 @@ function loadAttendees (filter: string = queryField.value, checkedIn: string = c
  
 	// TODO: some kind of pagination when displaying users
 	let query: string = `query UserAndTags($search: String!, $questions: [String!]!, $filter: UserFilter) {
-		search_user(search: $search, n: 25, offset: 0, filter: $filter) {
+		search_user_simple(search: $search, n: 25, offset: 0, filter: $filter) {
 			user {
 				id 
 				name 
@@ -313,7 +313,7 @@ function loadAttendees (filter: string = queryField.value, checkedIn: string = c
 			filter: registrationFilter
 		}
 	}), graphqlOptions).then((xhr, response: ISearchUserResponse) => {
-		let attendees: IGraphqlAttendee[] = response.data.search_user;
+		let attendees: IGraphqlAttendee[] = response.data.search_user_simple;
 
 		let attendeeList = document.getElementById("attendees")!;
 		let attendeeTemplate = <HTMLTemplateElement> document.getElementById("attendee-item")!;

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -148,35 +148,35 @@ function statusFormatter (time: string, by: string = "unknown"): string {
 }
 
 function checkIn (e: Event) {
-	let button = (<HTMLButtonElement> e.target)!;
-	let isCheckedIn: boolean = button.classList.contains("checked-in");
-	button.disabled = true;
-	let tag: string = tagSelector.value;
-	let id: string = button.parentElement!.parentElement!.id.slice(5);
-	let action: string = isCheckedIn ? "check_out" : "check_in";
+    let button = (<HTMLButtonElement> e.target)!;
+    let isCheckedIn: boolean = button.classList.contains("checked-in");
+    button.disabled = true;
+    let tag: string = tagSelector.value;
+    let id: string = button.parentElement!.parentElement!.id.slice(5);
+    let action: string = isCheckedIn ? "check_out" : "check_in";
 
-	let mutation: string = `mutation UserAndTags($user: ID!, $tag: String!) {
-	  ${action}(user: $user, tag: $tag) {
-	    tags {
-	      tag {
-	        name
-	      }
-	      checked_in
-	    }
-	  }
-	}`;
+    let mutation: string = `mutation UserAndTags($user: ID!, $tag: String!) {
+      ${action}(user: $user, tag: $tag) {
+        tags {
+          tag {
+            name
+          }
+          checked_in
+        }
+      }
+    }`;
 
-	qwest.post("/graphql", JSON.stringify({
-		query: mutation,
+    qwest.post("/graphql", JSON.stringify({
+        query: mutation,
         variables: {
             user: id,
             tag: tag
         }
-	}), graphqlOptions).catch((e, xhr, response) => {
-		alert(response.error);
-	}).complete(() => {
-		button.disabled = false;
-	});
+    }), graphqlOptions).catch((e, xhr, response) => {
+        alert(response.error);
+    }).complete(() => {
+        button.disabled = false;
+    });
 }
 
 function attachUserDeleteHandlers () {
@@ -518,7 +518,7 @@ document.getElementById("add-new-tag")!.addEventListener("click", e => {
 		return;
 	}
 
-	qwest.post(`/graphql`, JSON.stringify({
+	qwest.post("/graphql", JSON.stringify({
 		query: `mutation Tag($tag: String!) {
 			add_tag(tag: $tag) {
 				name
@@ -545,7 +545,7 @@ document.getElementById("add-new-tag")!.addEventListener("click", e => {
 
 // Populate checkboxes for question names
 qwest.post("/graphql", JSON.stringify({
-	query: `{ question_names }`
+	query: "{ question_names }"
 }), graphqlOptions).then((xhr, response) => {
 	let checkboxTemplate = <HTMLTemplateElement> document.getElementById("checkbox-item")!;
 	let checkboxContainer = document.getElementById("question-options")!;
@@ -576,7 +576,7 @@ qwest.post("/graphql", JSON.stringify({
 // Toggle display of question checkboxes
 document.querySelector("#question-options-wrapper span")!.addEventListener("click", e => {
 	let elem = document.getElementById("question-options")!;
-	elem.style.display = elem.style.display == 'none' ? '' : 'none';
+	elem.style.display = elem.style.display == "none" ? "" : "none";
 });
 
 document.getElementById("update-question-options")!.addEventListener("click", e => {
@@ -595,7 +595,7 @@ document.getElementById("attending-filter")!.addEventListener("change", e => {
 
 // Populate application branches select options
 qwest.post("/graphql", JSON.stringify({
-	query: `{ application_branches }`
+	query: "{ application_branches }"
 }), graphqlOptions).then((xhr, response) => {
 	let select = document.getElementById("branches-filter")!;
 	let branches = response.data.application_branches;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checkin2",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkin2",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Check-in for HackGT events",
   "main": "app.js",
   "scripts": {

--- a/server/app.ts
+++ b/server/app.ts
@@ -707,7 +707,7 @@ setupGraphQlRoutes(app, registration);
 
 // WebSocket server
 const server = http.createServer(app);
-const wss = new WebSocket.Server({ server });
+export const wss = new WebSocket.Server({ server });
 wss.on("connection", function(rawSocket, _request) {
 	let request = _request as express.Request;
 	cookieParserInstance(request, null!, async (err) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -620,43 +620,6 @@ apiRouter.route("/checkin").post(authenticateWithReject, postParser, async (requ
 	}
 });
 
-// Endpoint for adding tags to existing groups of attendees
-apiRouter.route("/data/addTag/:tag").put(authenticateWithReject, postParser, async (request, response) => {
-	let tag: string = request.params.tag;
-	let currentTag: string = request.body.currentTag;
-	if (!currentTag) {
-		response.status(400).json({
-			"error": "Must provide existing tag"
-		});
-		return;
-	}
-	try {
-		await Attendee.update({
-			["tags." + currentTag]: {
-				$exists: true
-			},
-			["tags." + tag]: {
-				$exists: false
-			},
-		}, {
-			["tags." + tag]: {
-				checked_in: false
-			}
-		}, {
-			multi: true
-		});
-		response.status(200).json({
-			"success": true
-		});
-	}
-	catch (e) {
-		console.log(e);
-		response.status(500).json({
-			"error": "An error occurred while adding tag to attendees"
-		});
-	}
-});
-
 app.use("/api", apiRouter);
 
 const indexTemplate = Handlebars.compile(fs.readFileSync(path.join(__dirname, STATIC_ROOT, "index.html"), "utf8"));

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -160,15 +160,15 @@ function resolver(registration: Registration): IResolver {
 
                 // Send updated information via web sockets
                 wss.clients.forEach(function each(client) {
-                if (client.readyState === WebSocket.OPEN) {
-                    client.send(JSON.stringify({
-                        id: args.user,
-                        tag: args.tag,
-                        checked_in: true,
-                        checked_in_date: date,
-                        checked_in_by: loggedInUser.user ? loggedInUser.user.username : ""
-                    }));
-                }
+                    if (client.readyState === WebSocket.OPEN) {
+                        client.send(JSON.stringify({
+                            id: args.user,
+                            tag: args.tag,
+                            checked_in: true,
+                            checked_in_date: date,
+                            checked_in_by: loggedInUser.user ? loggedInUser.user.username : ""
+                        }));
+                    }
                 });
 
                 return userInfo;
@@ -213,13 +213,13 @@ function resolver(registration: Registration): IResolver {
 
                 // Send updated information via web sockets
                 wss.clients.forEach(function each(client) {
-                if (client.readyState === WebSocket.OPEN) {
-                    client.send(JSON.stringify({
-                        id: args.user,
-                        tag: args.tag,
-                        checked_in: false
-                    }));
-                }
+                    if (client.readyState === WebSocket.OPEN) {
+                        client.send(JSON.stringify({
+                            id: args.user,
+                            tag: args.tag,
+                            checked_in: false
+                        }));
+                    }
                 });
 
                 return userInfo;

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -104,11 +104,15 @@ function resolver(registration: Registration): IResolver {
 					return [];
 				}
 				return Object.keys(attendee.tags).map(tag => {
+					const date = attendee.tags[tag].checked_in_date;
+
 					return {
 						tag: {
 							name: tag
 						},
-						checked_in: attendee.tags[tag].checked_in
+						checked_in: attendee.tags[tag].checked_in,
+						checked_in_date: date ? date.toISOString() : "",
+						checked_in_by: attendee.tags[tag].checked_in_by || ""
 					};
 				});
 			}
@@ -144,9 +148,10 @@ function resolver(registration: Registration): IResolver {
                     });
                 }
                 const loggedInUser = await getLoggedInUser(ctx);
+                const date = new Date();
                 attendee.tags[args.tag] = {
                     checked_in: true,
-                    checked_in_date: new Date(),
+                    checked_in_date: date,
                     checked_in_by: loggedInUser.user ? loggedInUser.user.username : ""
                 }
 
@@ -159,7 +164,9 @@ function resolver(registration: Registration): IResolver {
 						client.send(JSON.stringify({
 							id: args.user,
 							tag: args.tag,
-							checked_in: true
+							checked_in: true,
+							checked_in_date: date,
+							checked_in_by: loggedInUser.user ? loggedInUser.user.username : ""
 						}));
 					}
 				});

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -228,7 +228,7 @@ function resolver(registration: Registration): IResolver {
             /**
             * Add tag to all users
             */
-            add_tag: async(prev, args, ctx, schema) => {
+            add_tag: async (prev, args, ctx, schema) => {
                 // Return none if the tag already exists (prevent duplicates)
                 if (await Tag.findOne({ name: args.tag })) {
                     return null;

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -110,7 +110,7 @@ function resolver(registration: Registration): IResolver {
 
 				const forwarder = registration.forward({
                     path: "check_in.user",
-                    include: ["id"],
+                    include: ["id", "name", "email"],
                     head: `user(id: "${args.user}")`
                 });
                 const userInfo = await forwarder(prev, args, ctx, schema);
@@ -151,7 +151,7 @@ function resolver(registration: Registration): IResolver {
 
 				const forwarder = registration.forward({
                     path: "check_out.user",
-                    include: ["id"],
+                    include: ["id", "name", "email"],
                     head: `user(id: "${args.user}")`
                 });
                 const userInfo = await forwarder(prev, args, ctx, schema);

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -153,6 +153,7 @@ function resolver(registration: Registration): IResolver {
                 attendee.markModified('tags');
                 await attendee.save();
 
+                // Send updated information via web sockets
                 wss.clients.forEach(function each(client) {
 					if (client.readyState === WebSocket.OPEN) {
 						client.send(JSON.stringify({
@@ -203,6 +204,7 @@ function resolver(registration: Registration): IResolver {
                 attendee.markModified('tags');
                 await attendee.save();
 
+                // Send updated information via web sockets
                 wss.clients.forEach(function each(client) {
 					if (client.readyState === WebSocket.OPEN) {
 						client.send(JSON.stringify({

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -214,6 +214,20 @@ function resolver(registration: Registration): IResolver {
 				});
 
                 return userInfo;
+			}, 
+
+			/**
+			* Add tag to all users
+			*/
+			add_tag: async(prev, args, ctx, schema) => {
+				// Return none if the tag already exists (prevent duplicates)
+				if (await Tag.findOne({ name: args.tag })) {
+					return null;
+				}
+
+				const tag = new Tag({ name: args.tag });
+				await tag.save();
+				return { name: args.tag };
 			}
 		}
 	};

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -160,19 +160,19 @@ function resolver(registration: Registration): IResolver {
 
                 // Send updated information via web sockets
                 wss.clients.forEach(function each(client) {
-					if (client.readyState === WebSocket.OPEN) {
-						client.send(JSON.stringify({
-							id: args.user,
-							tag: args.tag,
-							checked_in: true,
-							checked_in_date: date,
-							checked_in_by: loggedInUser.user ? loggedInUser.user.username : ""
-						}));
-					}
-				});
+                if (client.readyState === WebSocket.OPEN) {
+                    client.send(JSON.stringify({
+                        id: args.user,
+                        tag: args.tag,
+                        checked_in: true,
+                        checked_in_date: date,
+                        checked_in_by: loggedInUser.user ? loggedInUser.user.username : ""
+                    }));
+                }
+                });
 
                 return userInfo;
-			},
+            },
 			/**
 			 * Check-out a user by specifying the tag name
 			 */
@@ -213,33 +213,33 @@ function resolver(registration: Registration): IResolver {
 
                 // Send updated information via web sockets
                 wss.clients.forEach(function each(client) {
-					if (client.readyState === WebSocket.OPEN) {
-						client.send(JSON.stringify({
-							id: args.user,
-							tag: args.tag,
-							checked_in: false
-						}));
-					}
-				});
+                if (client.readyState === WebSocket.OPEN) {
+                    client.send(JSON.stringify({
+                        id: args.user,
+                        tag: args.tag,
+                        checked_in: false
+                    }));
+                }
+                });
 
                 return userInfo;
-			}, 
+            }, 
 
-			/**
-			* Add tag to all users
-			*/
-			add_tag: async(prev, args, ctx, schema) => {
-				// Return none if the tag already exists (prevent duplicates)
-				if (await Tag.findOne({ name: args.tag })) {
-					return null;
-				}
+            /**
+            * Add tag to all users
+            */
+            add_tag: async(prev, args, ctx, schema) => {
+                // Return none if the tag already exists (prevent duplicates)
+                if (await Tag.findOne({ name: args.tag })) {
+                    return null;
+                }
 
-				const tag = new Tag({ name: args.tag });
-				await tag.save();
-				return { name: args.tag };
-			}
-		}
-	};
+                const tag = new Tag({ name: args.tag });
+                await tag.save();
+                return { name: args.tag };
+            }
+        }
+    };
 }
 
 /**


### PR DESCRIPTION
GraphQL changes:
* Added `add_tag` mutation for adding new tags
* Changed the `TagState` type to include `checked_in_date` and `checked_in_by`

Front end changes:
* Select registration question answers to show
* Filter attendees by applied/accepted/attending and by application branch (participant/mentor/volunteer)
* Add new tags 