### PR TITLE
Confirmation filter and view files / checkboxes.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -110,6 +110,10 @@
 									<select class="mdc-select" style="width: 300px;" id="branches-filter">
 										<option value="">All application branches</option>
 									</select>
+									<select class="mdc-select" style="width: 300px;"
+                                            id="confirmation-branches-filter">
+										<option value="">All confirmation branches</option>
+									</select>
 								</div>
 							</div>
 						</section>

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -346,7 +346,29 @@ function loadAttendees (filter: string = queryField.value, checkedIn: string = c
 					status.textContent = "";
 				}
 				if (attendee.user.questions) {
-					let registrationInformation = attendee.user.questions.map(info => `${info.name}: ${info.value}`);
+					const infoToText = (info: {
+						name: string;
+						value?: string;
+						values?: string[];
+						file?: {
+							path: string;
+							original_name: string;
+						}
+					}) => {
+						if (info.value) {
+							return `${info.name}: ${info.value}`;
+						}
+						else if (info.values) {
+							return `${info.name}: ${info.values.join(",")}`;
+						}
+						else if (info.file) {
+							const path = encodeURIComponent(info.file.path);
+							const url = `${location.protocol}//${location.host}/uploads?file=${path}`;
+							return `${info.name}: <a href="${url}">${info.file.original_name}</a>`;
+						}
+						return `${info.name}: Not given.`;
+					};
+					let registrationInformation = attendee.user.questions.map(infoToText);
 					existingNodes[i].querySelector("#additional-info")!.innerHTML = registrationInformation.join("<br>");
 				}
 			}

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -258,7 +258,11 @@ function loadAttendees (filter: string = queryField.value, checkedIn: string = c
 	if (branch.value) {
 		registrationFilter.application_branch = branch.value; 
 	}
- 
+	const confirmationBranch = document.getElementById("confirmation-branches-filter") as HTMLInputElement;
+	if (confirmationBranch.value) {
+		registrationFilter.confirmation_branch = confirmationBranch.value;
+	}
+
 	// TODO: some kind of pagination when displaying users
 	let query: string = `query UserAndTags($search: String!, $questions: [String!]!, $filter: UserFilter) {
 		search_user_simple(search: $search, n: 25, offset: 0, filter: $filter) {
@@ -584,11 +588,33 @@ qwest.post("/graphql", JSON.stringify({
 		select.appendChild(option);
 	}
 }).catch((e, xhr, response) => {
-	console.error(response);
+	console.error(response, e);
 	alert("Error fetching registration application branches");
 });
 
+// Populate application branches select options
+qwest.post("/graphql", JSON.stringify({
+	query: "{ confirmation_branches }"
+}), graphqlOptions).then((xhr, response) => {
+	let select = document.getElementById("confirmation-branches-filter")!;
+	let branches = response.data.confirmation_branches;
+
+	for (let curr of branches) {
+		let option = document.createElement("option");
+		option.textContent = curr;
+		option.value = curr;
+		select.appendChild(option);
+	}
+}).catch((e, xhr, response) => {
+	console.error(response, e);
+	alert("Error fetching registration confirmation branches");
+});
+
 document.getElementById("branches-filter")!.addEventListener("change", e => {
+	loadAttendees();
+});
+
+document.getElementById("confirmation-branches-filter")!.addEventListener("change", e => {
 	loadAttendees();
 });
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -4,6 +4,7 @@ import * as os from "os";
 import * as crypto from "crypto";
 import * as morgan from "morgan";
 import * as chalk from "chalk";
+import * as urlib from "url";
 
 import * as express from "express";
 import * as serveStatic from "serve-static";
@@ -672,6 +673,12 @@ apiRouter.route("/checkin").post(authenticateWithReject, postParser, async (requ
 });
 
 app.use("/api", apiRouter);
+
+// TODO: fix, you must be logged into registration to view this.
+app.route("/uploads").get(authenticateWithReject, async (request, response) => {
+	const url = urlib.parse(config.inputs.registration);
+	response.redirect(`${url.protocol}//${url.host}/${request.query.file}`);
+});
 
 const indexTemplate = Handlebars.compile(fs.readFileSync(path.join(__dirname, STATIC_ROOT, "index.html"), "utf8"));
 app.route("/").get(authenticateWithRedirect, async (request, response) => {


### PR DESCRIPTION
Ability to filter users by which confirmation branch they used _and_ be able to view files uploaded and multiple select fields (checkboxes).

This is a half-solution, to view the files you must be logged into registration.
Lets do this for now and make an issue to clean it up later?