### PR TITLE
Add details field with records of check-in and check-out events

### DIFF
--- a/api.graphql
+++ b/api.graphql
@@ -56,6 +56,15 @@ type Tag {
   name: String!
 }
 
+# Record of checked in / checked out activity
+type TagDetail {
+  checked_in: Boolean!
+  # Date when attendee was checked in or out
+  checked_in_date: String!
+  # The username of the admin that checked thte attendee in or out
+  checked_in_by: String! 
+}
+
 type TagState {
   tag: Tag!
   checked_in: Boolean!
@@ -63,6 +72,8 @@ type TagState {
   checked_in_date: String
   # The username of the admin that checked the attendee in
   checked_in_by: String!
+  # An array of previous checked in / checked out events
+  details: [TagDetail]!
 }
 
 # NOTE: Type names that forward to registration must match the type names

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -126,7 +126,14 @@ function resolver(registration: Registration): IResolver {
 						},
 						checked_in: attendee.tags[tag].checked_in,
 						checked_in_date: date ? date.toISOString() : "",
-						checked_in_by: attendee.tags[tag].checked_in_by || ""
+						checked_in_by: attendee.tags[tag].checked_in_by || "",
+						details: attendee.tags[tag].details.map((elem) => {
+							return {
+								checked_in: elem.checked_in,
+								checked_in_date: elem.checked_in_date.toISOString(),
+								checked_in_by: elem.checked_in_by
+							}
+						})
 					};
 				});
 			}
@@ -170,11 +177,20 @@ function resolver(registration: Registration): IResolver {
 				}
 				const loggedInUser = await getLoggedInUser(ctx);
 				const date = new Date();
+				const username = loggedInUser.user ? loggedInUser.user.username : "";
+
 				attendee.tags[args.tag] = {
 					checked_in: true,
 					checked_in_date: date,
-					checked_in_by: loggedInUser.user ? loggedInUser.user.username : ""
+					checked_in_by: username,
+					details: attendee.tags[args.tag] ? attendee.tags[args.tag].details : []
 				}
+
+				attendee.tags[args.tag].details.push({
+					checked_in: true,
+					checked_in_date: date,
+					checked_in_by: username
+				});
 
 				attendee.markModified('tags');
 				await attendee.save();
@@ -222,11 +238,22 @@ function resolver(registration: Registration): IResolver {
 					});
 				}
 				const loggedInUser = await getLoggedInUser(ctx);
+				const date = new Date();
+				const username = loggedInUser.user ? loggedInUser.user.username : "";
+
 				attendee.tags[args.tag] = {
 					checked_in: false,
-					checked_in_date: new Date(),
-					checked_in_by: loggedInUser.user ? loggedInUser.user.username : ""
+					checked_in_date: date,
+					checked_in_by: username,
+					details: attendee.tags[args.tag] ? attendee.tags[args.tag].details : []
 				}
+
+				attendee.tags[args.tag].details.push({
+					checked_in: false,
+					checked_in_date: date,
+					checked_in_by: username
+				});
+
 				attendee.markModified('tags');
 				await attendee.save();
 

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -29,10 +29,17 @@ export const User = mongoose.model<IUserMongoose>("User", new mongoose.Schema({
 	auth_keys: [String]
 }));
 
+export interface ITagDetailItem {
+	checked_in: boolean;
+	checked_in_date: Date;
+	checked_in_by: string;
+}
+
 export interface ITagItem {
 	checked_in: boolean;
 	checked_in_date?: Date;
 	checked_in_by?: string;
+	details: ITagDetailItem[];
 }
 
 export interface ITags {


### PR DESCRIPTION
The current tag schema includes fields for `checked_in`, `checked_in_by` and `checked_in_date`. If an attendee is checked in or out multiple times, these fields get overwritten every time.

This PR adds a `details` field to the tag schema to store all previous checked_in / checked_out events. 
Before (even if an attendee was checked in/out multiple times):
```
	"tags" : {
		"hackgt" : {
			"checked_in" : true,
			"checked_in_date" : ISODate("2018-10-09T22:20:51.106Z"),
			"checked_in_by" : "kexin"
		}
	},
```

With these changes:
```
	"tags" : {
		"hackgt" : {
			"checked_in" : true,
			"checked_in_date" : ISODate("2018-10-09T22:20:51.106Z"),
			"checked_in_by" : "kexin",
			"details" : [
				{
					"checked_in" : true,
					"checked_in_date" : ISODate("2018-10-09T22:20:16.968Z"),
					"checked_in_by" : "admin"
				},
				{
					"checked_in" : false,
					"checked_in_date" : ISODate("2018-10-09T22:20:18.874Z"),
					"checked_in_by" : "admin"
				},
				{
					"checked_in" : true,
					"checked_in_date" : ISODate("2018-10-09T22:20:51.106Z"),
					"checked_in_by" : "kexin"
				}
			]
		}
	},
```