### PR TITLE
Add graphql query for getting counts of checked in users for each tag

### DIFF
--- a/api.graphql
+++ b/api.graphql
@@ -36,6 +36,9 @@ type Query {
   question_branches: [String!]!
   # All possible question names, or names of question in a branch
   question_names(branch: String): [String!]
+  # Counts of checked in users per tag.
+  # Only includes tags that have at least one user checked in.
+  tag_counts(tags: [String!]): [TagData]!
 }
 
 # The root subscription type, all subscribes go through here
@@ -175,4 +178,11 @@ type File {
   path: String!
   # The size of the file in bytes
   size: Int!
+}
+
+# Aggregated count data for a tag
+type TagData {
+  name: String!
+  # Count of checked in users
+  count: Int!
 }


### PR DESCRIPTION
Added ability to query for aggregated counts of checked in users per tag. 

Sample query: 
```
{
  tag_counts {
    name
    count
  }
}
```

Sample response: 
```
{
  "data": {
    "tag_counts": [
      {
        "name": "dinner",
        "count": 11
      },
      {
        "name": "lunch",
        "count": 6
      },
      {
        "name": "hackgt",
        "count": 13
      }
    ]
  }
}
```

This makes querying for checkin data easier, since there's no straightforward way of getting aggregate checkin data at the moment, and it'll be nice to have for statgt projects.  