### PR TITLE
Add optional fields for start and end times to tag schema [WIP]

### DIFF
--- a/api.graphql
+++ b/api.graphql
@@ -17,7 +17,8 @@ type Mutation {
 # The root query type, use to query data
 type Query {
   # Get a list of unique tags currently available to set.
-  tags: [Tag!]!
+  # set only_current to true to only get events that are currently happening based on their start/end times
+  tags(only_current: Boolean): [Tag!]!
   # Retrieve user through a user ID or through the token passed to
   # Query. Leave id empty if you'd like to view the currently logged in
   # user.

--- a/api.graphql
+++ b/api.graphql
@@ -11,7 +11,7 @@ type Mutation {
   # Check-out a user by specifying the tag name
   check_out(user: ID!, tag: String!): UserAndTags
   # Add tag to all users
-  add_tag(tag: String!): Tag
+  add_tag(tag: String!, start: String, end: String): Tag
 }
 
 # The root query type, use to query data
@@ -57,6 +57,10 @@ type UserAndTags {
 type Tag {
   # The unique name of the tag (not human label)
   name: String!
+  # The start time of the event associated with the tag
+  start: String
+  # The end time of the event associated with the tag
+  end: String
 }
 
 # Record of checked in / checked out activity

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -49,7 +49,12 @@ function resolver(registration: Registration): IResolver {
 			 * Get a list of unique tags currently available to set.
 			 */
 			tags: async (prev, args, ctx) => {
-				return Tag.find();
+				const results = await Tag.find();
+				return results.map(elem => ({
+					name: elem.name,
+					start: elem.start ? elem.start.toISOString() : "",
+					end: elem.end ? elem.end.toISOString() : ""
+				}));
 			},
 			/**
 			 * Retrieve user through a user ID or through the token passed to
@@ -313,9 +318,16 @@ function resolver(registration: Registration): IResolver {
 					return null;
 				}
 
-				const tag = new Tag({ name: args.tag });
+				let tag = new Tag({ name: args.tag });
+				if (args.start) tag.start = new Date(args.start);
+				if (args.end) tag.end = new Date(args.end);
 				await tag.save();
-				return { name: args.tag };
+
+				return {
+					name: args.tag,
+					start: args.start ? args.start : "",
+					end: args.end ? args.end : ""
+				};
 			}
 		},
 		Subscription: {

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -49,7 +49,14 @@ function resolver(registration: Registration): IResolver {
 			 * Get a list of unique tags currently available to set.
 			 */
 			tags: async (prev, args, ctx) => {
-				const results = await Tag.find();
+				const curr = new Date();
+				const query = args.only_current ? {
+					$and: [
+						{start: {$lte: curr}},
+						{end: {$gte: curr}}
+					]
+				} : {};
+				const results = await Tag.find(query);
 				return results.map(elem => ({
 					name: elem.name,
 					start: elem.start ? elem.start.toISOString() : "",

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -76,6 +76,8 @@ export const Attendee = mongoose.model<IAttendeeMongoose>("Attendee", new mongoo
 // Master list of available tags
 export interface ITag {
 	name: string;
+	start?: Date;
+	end?: Date;
 }
 
 export type ITagMongoose = ITag & mongoose.Document;
@@ -85,5 +87,11 @@ export const Tag = mongoose.model<ITagMongoose>("Tag", new mongoose.Schema({
 		type: String,
 		required: true,
 		unique: true
+	},
+	start: {
+		type: Date
+	},
+	end: {
+		type: Date
 	}
 }));


### PR DESCRIPTION
Add support for associating optional start/end time attributes for checkin tags. The potential use case here would be to use the start/end times to only show tags for events that are currently occurring. 

Example for querying for tags:
```
{
  tags {
    name 
    start 
    end
  }
}
```
Example response:
```
{
  "data": {
    "tags": [
      {
        "name": "hackgt",
        "start": "",
        "end": ""
      },
      {
        "name": "breakfast",
        "start": "2018-10-12T02:08:48.595Z",
        "end": "2018-10-12T02:09:48.595Z"
      },
      {
        "name": "lunch",
        "start": "2018-10-12T02:22:09.693Z",
        "end": "2018-10-12T02:23:09.693Z"
      },
      {
        "name": "workshop",
        "start": "2018-10-12T02:32:05.624Z",
        "end": "2018-10-12T02:32:05.624Z"
      }
  }
}
```


Example for adding a tag:
```
mutation {
    add_tag(tag: "e", start: "2018-10-12T02:32:05.624Z", end: "2018-10-12T02:32:05.624Z") {
        name 
        start
        end
    }
}
```

**Should fix:**
Definitely could/should be more robust because currently, start/end is always null for queries/mutations that _are not_ `tags` or `add_tag`.  For example, 
```
{
 search_user_simple(n: 20, search: "john", offset: 0) {
  user {
    id
  }
  tags {
  	tag {
      	    name 
      	    end 
      	    start
    	}
    	checked_in
     }
  }
}
```
will result in `null` for `start` and `end` of all tags, even if the tags have a `start` or `end` attribute in mongo. Fixing this isn't super necessary for the use case mentioned earlier though.