### PR TITLE
Hotfix for null/undefined warnOnDuplicates & GraphQL API improvements

### DIFF
--- a/api.graphql
+++ b/api.graphql
@@ -6,10 +6,8 @@ schema {
 
 # The root mutation type, use it to change things
 type Mutation {
-  # Check-in a user by specifying the tag name
-  check_in(user: ID!, tag: String!): UserAndTags
-  # Check-out a user by specifying the tag name
-  check_out(user: ID!, tag: String!): UserAndTags
+  # Check-in or check-out a user by specifying the tag name.  Check-in when checkin is set to true; check-out when checkin is set to false
+  check_in(user: ID!, tag: String!, checkin: Boolean!): UserAndTags
   # Add tag to all users
   add_tag(tag: String!, start: String, end: String, warnOnDuplicates: Boolean = false): Tag
 }

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -157,20 +157,17 @@ function checkIn(e: Event) {
         }
     }).then(response => {
         button.disabled = false;
-        console.log(response);
 
         if (response && response.data) {
-            console.log("inside")
             let checkin_success = null;
             for (let i = 0; i < response.data.check_in.tags.length; i++) {
                 let tagData = response.data.check_in.tags[i];
-                console.log(tagData.tag.name, tag);
+
                 if (tagData.tag.name === tag) {
                     checkin_success = tagData.checkin_success;
                     break;
                 }
             }
-            console.log("checkin_success", checkin_success)
             if (!checkin_success) {
                 swal("Glitch in the matrix", "Your local check-in data is out-of-date.  Please refresh the page to continue", "error");
             }

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -14,425 +14,455 @@ import gql from 'graphql-tag';
 import swal from 'sweetalert2';
 
 const httpLink = createHttpLink({
-	uri: "/graphql",
-	credentials: "same-origin"
+    uri: "/graphql",
+    credentials: "same-origin"
 });
 
 const wsProtocol = location.protocol === "http:" ? "ws" : "wss";
 const wsClient = new SubscriptionClient(`${wsProtocol}://${window.location.host}/graphql`, {
-	reconnect: true
+    reconnect: true
 });
 const wsLink = new WebSocketLink(wsClient);
 
 const link = split(
-  // split based on operation type
-  operation => {
-	const operationAST = getOperationAST(operation.query, operation.operationName);
-	return !!operationAST && operationAST.operation === 'subscription';
-  },
-  wsLink,
-  httpLink
+    // split based on operation type
+    operation => {
+        const operationAST = getOperationAST(operation.query, operation.operationName);
+        return !!operationAST && operationAST.operation === 'subscription';
+    },
+    wsLink,
+    httpLink
 );
 
 const client = new ApolloClient({
-	link: link,
-	cache: new InMemoryCache(),
-	defaultOptions: {
-		query: {
-			fetchPolicy: "network-only"
-		}
-	}
+    link: link,
+    cache: new InMemoryCache(),
+    defaultOptions: {
+        query: {
+            fetchPolicy: "network-only"
+        }
+    }
 });
 
 class State {
-	public linkID: string;
-	public sectionID: string;
-	public isDisplayed: boolean = false;
-	private link: HTMLAnchorElement;
-	private section: HTMLElement;
-	private readonly drawerSelectedClass = "mdc-temporary-drawer--selected";
-	constructor(linkID: string, sectionID: string) {
-		this.linkID = linkID;
-		this.sectionID = sectionID;
+    public linkID: string;
+    public sectionID: string;
+    public isDisplayed: boolean = false;
+    private link: HTMLAnchorElement;
+    private section: HTMLElement;
+    private readonly drawerSelectedClass = "mdc-temporary-drawer--selected";
 
-		let link = document.getElementById(linkID);
-		if (!link) {
-			throw new Error("Invalid link ID");
-		}
-		this.link = link as HTMLAnchorElement;
-		this.link.addEventListener("click", async e => {
-			await delay(10);
-			drawer.open = false;
-			this.show();
-			if (States["checkin"] === this) {
-				loadAttendees();
-			}
-		});
+    constructor(linkID: string, sectionID: string) {
+        this.linkID = linkID;
+        this.sectionID = sectionID;
 
-		let section = document.getElementById(sectionID);
-		if (!section) {
-			throw new Error("Invalid section ID");
-		}
-		this.section = section as HTMLElement;
-	}
-	static hideAll(): void {
-		Object.keys(States).forEach(stateKey => States[stateKey].hide());
-	}
-	hide(): void {
-		this.isDisplayed = false;
-		this.link.classList.remove(this.drawerSelectedClass);
-		this.section.style.display = "none";
-	}
-	show(hideOthers: boolean = true): void {
-		if (hideOthers) State.hideAll();
-		this.isDisplayed = true;
-		this.link.classList.add(this.drawerSelectedClass);
-		this.section.style.display = "block";
-		window.scrollTo(0, 0);
-	}
+        let link = document.getElementById(linkID);
+        if (!link) {
+            throw new Error("Invalid link ID");
+        }
+        this.link = link as HTMLAnchorElement;
+        this.link.addEventListener("click", async e => {
+            await delay(10);
+            drawer.open = false;
+            this.show();
+            if (States["checkin"] === this) {
+                loadAttendees();
+            }
+        });
+
+        let section = document.getElementById(sectionID);
+        if (!section) {
+            throw new Error("Invalid section ID");
+        }
+        this.section = section as HTMLElement;
+    }
+
+    static hideAll(): void {
+        Object.keys(States).forEach(stateKey => States[stateKey].hide());
+    }
+
+    hide(): void {
+        this.isDisplayed = false;
+        this.link.classList.remove(this.drawerSelectedClass);
+        this.section.style.display = "none";
+    }
+
+    show(hideOthers: boolean = true): void {
+        if (hideOthers) State.hideAll();
+        this.isDisplayed = true;
+        this.link.classList.add(this.drawerSelectedClass);
+        this.section.style.display = "block";
+        window.scrollTo(0, 0);
+    }
 }
+
 const States: { [key: string]: State } = {
-	"checkin": new State("open-checkin", "checkin"),
-	"users": new State("open-users", "manage-users"),
-	"tags": new State("open-tags", "edit-tags")
+    "checkin": new State("open-checkin", "checkin"),
+    "users": new State("open-users", "manage-users"),
+    "tags": new State("open-tags", "edit-tags")
 };
 
 // Set the correct state on page load
 function readURLHash() {
-	let state: State | undefined = States[window.location.hash.substr(1)];
-	if (state) {
-		state.show();
-	}
-	else {
-		States["checkin"].show();
-	}
+    let state: State | undefined = States[window.location.hash.substr(1)];
+    if (state) {
+        state.show();
+    } else {
+        States["checkin"].show();
+    }
 }
+
 readURLHash();
 window.addEventListener("hashchange", readURLHash);
 
-function delay (milliseconds: number) {
-	return new Promise<void>(resolve => {
-		setTimeout(resolve, milliseconds);
-	});
+function delay(milliseconds: number) {
+    return new Promise<void>(resolve => {
+        setTimeout(resolve, milliseconds);
+    });
 }
 
-function statusFormatter (time: string, by: string): string {
-	// Escape possible HTML in username
-	by = by.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-	const date: Date = new Date(time);
-	return `Checked in <abbr title="${moment(date).format("dddd, MMMM Do YYYY, h:mm:ss A")}">${moment(time).fromNow()}</abbr> by <code>${by}</code>`;
+function statusFormatter(time: string, by: string): string {
+    // Escape possible HTML in username
+    by = by.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    const date: Date = new Date(time);
+    return `Checked in <abbr title="${moment(date).format("dddd, MMMM Do YYYY, h:mm:ss A")}">${moment(time).fromNow()}</abbr> by <code>${by}</code>`;
 }
 
-function checkIn (e: Event) {
-	let button = (<HTMLButtonElement> e.target)!;
-	let isCheckedIn: boolean = button.classList.contains("checked-in");
-	button.disabled = true;
-	let tag: string = tagSelector.value;
-	let id: string = button.parentElement!.parentElement!.id.slice(5);
-	let action: string = isCheckedIn ? "check_out" : "check_in";
+function checkIn(e: Event) {
+    let button = (<HTMLButtonElement>e.target)!;
+    let isCheckedIn: boolean = button.classList.contains("checked-in");
+    button.disabled = true;
+    let tag: string = tagSelector.value;
+    let id: string = button.parentElement!.parentElement!.id.slice(5);
+    let checkingIn: boolean = !isCheckedIn;
 
-	const mutation = gql`mutation UserAndTags($user: ID!, $tag: String!) {
-	  ${action}(user: $user, tag: $tag) {
-		tags {
-		  tag {
-			name
-		  }
-		  checked_in
-		}
-	  }
-	}`;
+    const mutation = gql`mutation ($user: ID!, $tag: String!, $checkin: Boolean!) {
+        check_in(user: $user, tag: $tag, checkin: $checkin) {
+            tags {
+                tag {
+                    name
+                }
+                checked_in
+                checkin_success
+            }
+        }
+    }`;
 
-	client.mutate<GQL.IMutation>({
-		mutation: mutation,
-		variables: {
-			user: id,
-			tag: tag
-		}
-	}).then(response => {
-		button.disabled = false;
-	}).catch(error => {
-		console.error(error);
-		swal("Nah fam ✋", "An error is preventing us from checking in this user", "error");
-		button.disabled = false;
-	});
+    client.mutate<GQL.IMutation>({
+        mutation: mutation,
+        variables: {
+            user: id,
+            tag: tag,
+            checkin: checkingIn
+        }
+    }).then(response => {
+        button.disabled = false;
+        console.log(response);
+
+        if (response && response.data) {
+            console.log("inside")
+            let checkin_success = null;
+            for (let i = 0; i < response.data.check_in.tags.length; i++) {
+                let tagData = response.data.check_in.tags[i];
+                console.log(tagData.tag.name, tag);
+                if (tagData.tag.name === tag) {
+                    checkin_success = tagData.checkin_success;
+                    break;
+                }
+            }
+            console.log("checkin_success", checkin_success)
+            if (!checkin_success) {
+                swal("Glitch in the matrix", "Your local check-in data is out-of-date.  Please refresh the page to continue", "error");
+            }
+        } else {
+            swal("Empty server response", "The server didn't respond with the expected data", "error");
+        }
+
+    }).catch(error => {
+        console.error(error);
+        swal("Nah fam ✋", "An error is preventing us from checking in this user", "error");
+        button.disabled = false;
+    });
 }
 
-function attachUserDeleteHandlers () {
-	let deleteButtons = document.querySelectorAll("#manage-users .actions > button");
-	for (let i = 0; i < deleteButtons.length; i++) {
-		deleteButtons[i].addEventListener("click", e => {
-			let source = (<HTMLButtonElement> e.target)!;
-			let username: string = source.parentElement!.parentElement!.dataset.username!;
-			let extraWarn: boolean = !!source.parentElement!.querySelector(".status");
-			const extraWarnMessage = `**YOU ARE TRYING TO DELETE THE ACCOUNT THAT YOU ARE CURRENTLY LOGGED IN WITH. THIS WILL DELETE YOUR USER AND LOG YOU OUT.**`;
+function attachUserDeleteHandlers() {
+    let deleteButtons = document.querySelectorAll("#manage-users .actions > button");
+    for (let i = 0; i < deleteButtons.length; i++) {
+        deleteButtons[i].addEventListener("click", e => {
+            let source = (<HTMLButtonElement>e.target)!;
+            let username: string = source.parentElement!.parentElement!.dataset.username!;
+            let extraWarn: boolean = !!source.parentElement!.querySelector(".status");
+            const extraWarnMessage = `**YOU ARE TRYING TO DELETE THE ACCOUNT THAT YOU ARE CURRENTLY LOGGED IN WITH. THIS WILL DELETE YOUR USER AND LOG YOU OUT.**`;
 
-			let shouldContinue: boolean = confirm(`${extraWarn ? extraWarnMessage + "\n\n": ""}Are you sure that you want to delete the user '${username}'?`);
-			if (!shouldContinue)
-				return;
+            let shouldContinue: boolean = confirm(`${extraWarn ? extraWarnMessage + "\n\n" : ""}Are you sure that you want to delete the user '${username}'?`);
+            if (!shouldContinue)
+                return;
 
-			source.disabled = true;
-			qwest.delete("/api/user/update", {
-				username: username
-			}).then((xhr, response) => {
-				let toRemove = document.querySelector(`li[data-username="${username}"]`);
-				if (toRemove && toRemove.parentElement) {
-					toRemove.parentElement.removeChild(toRemove);
-				}
-				// Reattach button event handlers
-				attachUserDeleteHandlers();
+            source.disabled = true;
+            qwest.delete("/api/user/update", {
+                username: username
+            }).then((xhr, response) => {
+                let toRemove = document.querySelector(`li[data-username="${username}"]`);
+                if (toRemove && toRemove.parentElement) {
+                    toRemove.parentElement.removeChild(toRemove);
+                }
+                // Reattach button event handlers
+                attachUserDeleteHandlers();
 
-				if (response.reauth) {
-					window.location.reload();
-				}
-			}).catch((e, xhr, response) => {
-				swal("Unable to process request", response.error, "error");
-			}).complete(() => {
-				source.disabled = false;
-			});
-		});
-	}
+                if (response.reauth) {
+                    window.location.reload();
+                }
+            }).catch((e, xhr, response) => {
+                swal("Unable to process request", response.error, "error");
+            }).complete(() => {
+                source.disabled = false;
+            });
+        });
+    }
 }
 
-let queryField = <HTMLInputElement> document.getElementById("query")!;
+let queryField = <HTMLInputElement>document.getElementById("query")!;
 queryField.addEventListener("keyup", e => {
-	loadAttendees();
+    loadAttendees();
 });
-let checkedInFilterField = <HTMLSelectElement> document.getElementById("checked-in-filter")!;
+let checkedInFilterField = <HTMLSelectElement>document.getElementById("checked-in-filter")!;
 checkedInFilterField.addEventListener("change", e => {
-	loadAttendees();
+    loadAttendees();
 });
-let tagSelector = <HTMLSelectElement> document.getElementById("tag-choose")!;
+let tagSelector = <HTMLSelectElement>document.getElementById("tag-choose")!;
 tagSelector.addEventListener("change", e => {
-	if (!States["checkin"].isDisplayed) {
-		States["checkin"].show();
-	}
-	drawer.open = false;
-	loadAttendees();
+    if (!States["checkin"].isDisplayed) {
+        States["checkin"].show();
+    }
+    drawer.open = false;
+    loadAttendees();
 });
 
-function loadAttendees (filter: string = queryField.value, checkedIn: string = checkedInFilterField.value) {
-	let status = document.getElementById("loading-status")!;
-	status.textContent = "Loading...";
+function loadAttendees(filter: string = queryField.value, checkedIn: string = checkedInFilterField.value) {
+    let status = document.getElementById("loading-status")!;
+    status.textContent = "Loading...";
 
-	let tag = tagSelector.value;
+    let tag = tagSelector.value;
 
-	// Get checked question options
-	let checked: string[] = [];
-	let checkedElems = document.querySelectorAll("#question-options input:checked") as NodeListOf<HTMLInputElement>;
-	for (let i = 0; i < checkedElems.length; i++) {
-		checked.push(checkedElems[i].value);
-	}
+    // Get checked question options
+    let checked: string[] = [];
+    let checkedElems = document.querySelectorAll("#question-options input:checked") as NodeListOf<HTMLInputElement>;
+    for (let i = 0; i < checkedElems.length; i++) {
+        checked.push(checkedElems[i].value);
+    }
 
-	// Create filter query based on selected values
-	let registrationFilter: GQL.IUserFilter = {};
-	let subgroup = document.getElementById("attending-filter") as HTMLInputElement;
-	if (subgroup.value) {
-		if (subgroup.value === "attending") {
-			registrationFilter.confirmed = true;
-			registrationFilter.accepted = true;
-		} else if (subgroup.value === "accepted") {
-			registrationFilter.accepted = true;
-		} else if (subgroup.value === "applied") {
-			registrationFilter.applied = true;
-		}
-	}
-	let branch = document.getElementById("branches-filter") as HTMLInputElement;
-	if (branch.value) {
-		registrationFilter.application_branch = branch.value; 
-	}
-	const confirmationBranch = document.getElementById("confirmation-branches-filter") as HTMLInputElement;
-	if (confirmationBranch.value) {
-		registrationFilter.confirmation_branch = confirmationBranch.value;
-	}
+    // Create filter query based on selected values
+    let registrationFilter: GQL.IUserFilter = {};
+    let subgroup = document.getElementById("attending-filter") as HTMLInputElement;
+    if (subgroup.value) {
+        if (subgroup.value === "attending") {
+            registrationFilter.confirmed = true;
+            registrationFilter.accepted = true;
+        } else if (subgroup.value === "accepted") {
+            registrationFilter.accepted = true;
+        } else if (subgroup.value === "applied") {
+            registrationFilter.applied = true;
+        }
+    }
+    let branch = document.getElementById("branches-filter") as HTMLInputElement;
+    if (branch.value) {
+        registrationFilter.application_branch = branch.value;
+    }
+    const confirmationBranch = document.getElementById("confirmation-branches-filter") as HTMLInputElement;
+    if (confirmationBranch.value) {
+        registrationFilter.confirmation_branch = confirmationBranch.value;
+    }
 
-	const query = gql`query UserAndTags($search: String!, $questions: [String!]!, $filter: UserFilter) {
-		search_user_simple(search: $search, n: 25, offset: 0, filter: $filter) {
-			user {
-				id 
-				name 
-				email
-				questions(names: $questions) {
-					name
-					value
-					values
-					file {
-						path
-						original_name
-					}
-				} 
-			} 
-			tags {
-				tag {
-					name 
-				} 
-				checked_in
-				checked_in_by
-				checked_in_date 
-			} 
-		} 
-	}`;
+    const query = gql`query UserAndTags($search: String!, $questions: [String!]!, $filter: UserFilter) {
+        search_user_simple(search: $search, n: 25, offset: 0, filter: $filter) {
+            user {
+                id
+                name
+                email
+                questions(names: $questions) {
+                    name
+                    value
+                    values
+                    file {
+                        path
+                        original_name
+                    }
+                }
+            }
+            tags {
+                tag {
+                    name
+                }
+                checked_in
+                checked_in_by
+                checked_in_date
+                last_successful_checkin {
+                    checked_in
+                    checked_in_by
+                    checked_in_date
+                }
+            }
+        }
+    }`;
 
-	client.query<GQL.IQuery>({
-			query: query,
-			variables: {
-				search: filter || " ",
-				questions: checked,
-				filter: registrationFilter				
-			}
-		}).then(response => {
-			let attendees = response.data.search_user_simple;
+    client.query<GQL.IQuery>({
+        query: query,
+        variables: {
+            search: filter || " ",
+            questions: checked,
+            filter: registrationFilter
+        }
+    }).then(response => {
+        let attendees = response.data.search_user_simple;
 
-			let attendeeList = document.getElementById("attendees")!;
-			let attendeeTemplate = <HTMLTemplateElement> document.getElementById("attendee-item")!;
-			let numberOfExistingNodes = document.querySelectorAll("#attendees li").length;
+        let attendeeList = document.getElementById("attendees")!;
+        let attendeeTemplate = <HTMLTemplateElement>document.getElementById("attendee-item")!;
+        let numberOfExistingNodes = document.querySelectorAll("#attendees li").length;
 
-			if (!attendeeList.firstChild || numberOfExistingNodes < attendees.length) {
-				// First load, preallocate children
-				status.textContent = "Preallocating nodes...";
-				for (let i = numberOfExistingNodes; i < attendees.length; i++) {
-					let node = document.importNode(attendeeTemplate.content, true) as DocumentFragment;
-					node.querySelector("li")!.style.display = "none";
-					node.querySelector(".actions > button")!.addEventListener("click", checkIn);
-					attendeeList.appendChild(node);
-				}
-				(<any> window).mdc.autoInit();
-				console.warn(`Allocated ${attendees.length - numberOfExistingNodes} nodes due to insufficient number`);
-				status.textContent = "Loading...";
-			}
+        if (!attendeeList.firstChild || numberOfExistingNodes < attendees.length) {
+            // First load, preallocate children
+            status.textContent = "Preallocating nodes...";
+            for (let i = numberOfExistingNodes; i < attendees.length; i++) {
+                let node = document.importNode(attendeeTemplate.content, true) as DocumentFragment;
+                node.querySelector("li")!.style.display = "none";
+                node.querySelector(".actions > button")!.addEventListener("click", checkIn);
+                attendeeList.appendChild(node);
+            }
+            (<any>window).mdc.autoInit();
+            console.warn(`Allocated ${attendees.length - numberOfExistingNodes} nodes due to insufficient number`);
+            status.textContent = "Loading...";
+        }
 
-			// Reuse nodes already loaded from template
-			let existingNodes = document.querySelectorAll("#attendees li") as NodeListOf<HTMLElement>;
-			for (let i = 0; i < existingNodes.length; i++) {
-				let attendee = attendees[i];
-				if (!!attendee) {
-					existingNodes[i].style.display = "";
+        // Reuse nodes already loaded from template
+        let existingNodes = document.querySelectorAll("#attendees li") as NodeListOf<HTMLElement>;
+        for (let i = 0; i < existingNodes.length; i++) {
+            let attendee = attendees[i];
+            if (!!attendee) {
+                existingNodes[i].style.display = "";
 
-					existingNodes[i].id = "item-" + attendee.user.id;
-					existingNodes[i].querySelector("#name")!.textContent = attendee.user.name;
-					existingNodes[i].querySelector("#emails")!.textContent = attendee.user.email;
+                existingNodes[i].id = "item-" + attendee.user.id;
+                existingNodes[i].querySelector("#name")!.textContent = attendee.user.name;
+                existingNodes[i].querySelector("#emails")!.textContent = attendee.user.email;
 
-					let button = existingNodes[i].querySelector(".actions > button")!;
-					let status = existingNodes[i].querySelector(".actions > span.status")!;
+                let button = existingNodes[i].querySelector(".actions > button")!;
+                let status = existingNodes[i].querySelector(".actions > span.status")!;
 
-					// Determine if user has the current tag
-					let tagInfo = attendee.tags.filter(curr => curr.tag.name === tag );
+                // Determine if user has the current tag
+                let tagInfo = attendee.tags.filter(curr => curr.tag.name === tag);
 
-					if (tagInfo.length > 0 && tagInfo[0].checked_in) {
-						button.textContent = "Check out";
-						button.classList.add("checked-in");
+                if (tagInfo.length > 0 && tagInfo[0].last_successful_checkin && tagInfo[0].last_successful_checkin!.checked_in) {
+                    button.textContent = "Check out";
+                    button.classList.add("checked-in");
 
-						let date = tagInfo[0].checked_in_date;
-						if (date && tagInfo[0].checked_in_by) {
-							status.innerHTML = statusFormatter(date, tagInfo[0].checked_in_by);
-						}
-					}
-					else {
-						button.textContent = "Check in";
-						button.classList.remove("checked-in");
-						status.textContent = "";
-					}
-					if (attendee.user.questions) {
-						const infoToText = (info: GQL.IFormItem) => {
-							if (info.value) {
-								return `${info.name}: ${info.value}`;
-							}
-							else if (info.values) {
-								return `${info.name}: ${info.values.join(",")}`;
-							}
-							else if (info.file) {
-								const path = encodeURIComponent(info.file.path);
-								const url = `${location.protocol}//${location.host}/uploads?file=${path}`;
-								return `${info.name}: <a href="${url}">${info.file.original_name}</a>`;
-							}
-							return `${info.name}: Not given.`;
-						};
-						let registrationInformation = attendee.user.questions.map(infoToText);
-						existingNodes[i].querySelector("#additional-info")!.innerHTML = registrationInformation.join("<br>");
-					}
-				}
-				else {
-					existingNodes[i].style.display = "none";
-					existingNodes[i].id = "";
-				}
-			}
-			tag = tag || "no tags found";
-			tag = tag.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-			status.innerHTML = `Found ${attendees.length} attendee${attendees.length === 1 ? "" : "s"} (<code>${tag}</code>)`;
-		}).catch(error => {
-			console.error(error);
-			swal("Nah fam ✋", "Error fetching participants", "error");
-		});
+                    let date = tagInfo[0].last_successful_checkin!.checked_in_date;
+                    if (date &&  tagInfo[0].last_successful_checkin!.checked_in_by) {
+                        status.innerHTML = statusFormatter(date, tagInfo[0].last_successful_checkin!.checked_in_by);
+                    }
+                } else {
+                    button.textContent = "Check in";
+                    button.classList.remove("checked-in");
+                    status.textContent = "";
+                }
+                if (attendee.user.questions) {
+                    const infoToText = (info: GQL.IFormItem) => {
+                        if (info.value) {
+                            return `${info.name}: ${info.value}`;
+                        } else if (info.values) {
+                            return `${info.name}: ${info.values.join(",")}`;
+                        } else if (info.file) {
+                            const path = encodeURIComponent(info.file.path);
+                            const url = `${location.protocol}//${location.host}/uploads?file=${path}`;
+                            return `${info.name}: <a href="${url}">${info.file.original_name}</a>`;
+                        }
+                        return `${info.name}: Not given.`;
+                    };
+                    let registrationInformation = attendee.user.questions.map(infoToText);
+                    existingNodes[i].querySelector("#additional-info")!.innerHTML = registrationInformation.join("<br>");
+                }
+            } else {
+                existingNodes[i].style.display = "none";
+                existingNodes[i].id = "";
+            }
+        }
+        tag = tag || "no tags found";
+        tag = tag.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        status.innerHTML = `Found ${attendees.length} attendee${attendees.length === 1 ? "" : "s"} (<code>${tag}</code>)`;
+    }).catch(error => {
+        console.error(error);
+        swal("Nah fam ✋", "Error fetching participants", "error");
+    });
 }
 
 function updateTagSelectors(newTags: string[]) {
-	// Get current list of tags
-	let tags: string[] = Array.prototype.slice.call(document.querySelectorAll("#tag-choose > option")).map((el: HTMLOptionElement) => {
-		return el.textContent;
-	});
-	for (let curr of newTags) {
-		if (tags.indexOf(curr) === -1) {
-			const tagsList = document.querySelectorAll("select.tags");
-			Array.prototype.slice.call(tagsList).forEach((el: HTMLSelectElement) => {
-				let tagOption = document.createElement("option");
-				tagOption.textContent = curr;
-				el.appendChild(tagOption);
-			});
-		}
-	}
+    // Get current list of tags
+    let tags: string[] = Array.prototype.slice.call(document.querySelectorAll("#tag-choose > option")).map((el: HTMLOptionElement) => {
+        return el.textContent;
+    });
+    for (let curr of newTags) {
+        if (tags.indexOf(curr) === -1) {
+            const tagsList = document.querySelectorAll("select.tags");
+            Array.prototype.slice.call(tagsList).forEach((el: HTMLSelectElement) => {
+                let tagOption = document.createElement("option");
+                tagOption.textContent = curr;
+                el.appendChild(tagOption);
+            });
+        }
+    }
 }
 
 mdc.ripple.MDCRipple.attachTo(document.querySelector(".mdc-ripple-surface"));
 let drawer = new mdc.drawer.MDCTemporaryDrawer(document.querySelector(".mdc-temporary-drawer"));
 document.querySelector("nav.toolbar > i:first-of-type")!.addEventListener("click", () => {
-	drawer.open = !drawer.open;
+    drawer.open = !drawer.open;
 });
 
 
 document.getElementById("add-update-user")!.addEventListener("click", e => {
-	let button = (<HTMLButtonElement> e.target)!;
-	button.disabled = true;
+    let button = (<HTMLButtonElement>e.target)!;
+    button.disabled = true;
 
-	let usernameInput = <HTMLInputElement> document.getElementById("manage-username");
-	let passwordInput = <HTMLInputElement> document.getElementById("manage-password");
-	let username = usernameInput.value.trim();
-	let password = passwordInput.value;
-	qwest.put("/api/user/update", {
-		username: username,
-		password: password
-	}).then((xhr, response) => {
-		if (response.created) {
-			swal("Got it!", `User '${username}' was successfully created`, "success");
-		}
-		else {
-			swal("Got it!", `Password for user '${username}' successfully updated. All active sessions with this account will need to log in again.`, "success");
-		}
-		window.location.reload();
+    let usernameInput = <HTMLInputElement>document.getElementById("manage-username");
+    let passwordInput = <HTMLInputElement>document.getElementById("manage-password");
+    let username = usernameInput.value.trim();
+    let password = passwordInput.value;
+    qwest.put("/api/user/update", {
+        username: username,
+        password: password
+    }).then((xhr, response) => {
+        if (response.created) {
+            swal("Got it!", `User '${username}' was successfully created`, "success")
+                .then(() => window.location.reload());
+        } else {
+            swal("Got it!", `Password for user '${username}' successfully updated. All active sessions with this account will need to log in again.`, "success")
+                .then(() => window.location.reload());
+        }
 
-	}).catch((e, xhr, response) => {
-		swal("Unable to process request", response.error, "error");
-	}).complete(() => {
-		button.disabled = false;
-	});
+
+    }).catch((e, xhr, response) => {
+        swal("Unable to process request", response.error, "error");
+    }).complete(() => {
+        button.disabled = false;
+    });
 });
 
 // Add tags to users
 document.getElementById("add-new-tag")!.addEventListener("click", e => {
-	let button = e.target as HTMLButtonElement;
-	button.disabled = true;
+    let button = e.target as HTMLButtonElement;
+    button.disabled = true;
 
-	let tagInput = <HTMLInputElement> document.getElementById("new-tag-name");
-	let tagStart = <HTMLInputElement> document.getElementById("new-tag-start-dt");
-	let tagEnd = <HTMLInputElement> document.getElementById("new-tag-end-dt");
-	let tagWarnDuplicates = <HTMLInputElement> document.getElementById("tag-warn-duplicate");
+    let tagInput = <HTMLInputElement>document.getElementById("new-tag-name");
+    let tagStart = <HTMLInputElement>document.getElementById("new-tag-start-dt");
+    let tagEnd = <HTMLInputElement>document.getElementById("new-tag-end-dt");
+    let tagWarnDuplicates = <HTMLInputElement>document.getElementById("tag-warn-duplicate");
 
-	let tag = tagInput.value.trim().toLowerCase();
-	if (!tag) {
-		swal("Enter a tag name", "", "warning");
-		button.disabled = false;
-		return;
-	}
+    let tag = tagInput.value.trim().toLowerCase();
+    if (!tag) {
+        swal("Enter a tag name", "", "warning");
+        button.disabled = false;
+        return;
+    }
 
-	const mutation = gql `
+    const mutation = gql`
 	mutation Tag($tag: String!, $start: String, $end: String, $warnOnDuplicates: Boolean = false) {
 		add_tag(tag: $tag, start: $start, end: $end, warnOnDuplicates: $warnOnDuplicates) {
 			name
@@ -442,211 +472,216 @@ document.getElementById("add-new-tag")!.addEventListener("click", e => {
 		}
 	}`;
 
-	client.mutate({
-		mutation: mutation,
-		variables: {
-			tag: tag,
+    client.mutate({
+        mutation: mutation,
+        variables: {
+            tag: tag,
             start: tagStart.value,
             end: tagEnd.value,
             warnOnDuplicates: tagWarnDuplicates.checked
-		}
-	}).then(response => {
-		// Add to tag selectors
-		updateTagSelectors([tag]);
+        }
+    }).then(response => {
+        // Add to tag selectors
+        updateTagSelectors([tag]);
 
-		// if the API returns null, the tag already exists, so show a warning
-		if (response && response.hasOwnProperty("data")
-			&& response.data && response.data.hasOwnProperty("add_tag")
-			&& !response.data.add_tag) {
-			swal({
-				title: "Tag already exists",
-				html: `The tag <strong>${tag}</strong> already exists.  Try again with a different name.`,
-				type: "warning"
-			});
-		} else {
-			document.querySelector(`label[for="new-tag-name"]`)!.classList.remove("mdc-textfield__label--float-above");
-			swal("Got it!", "Successfully created tag", "success");
+        // if the API returns null, the tag already exists, so show a warning
+        if (response && response.hasOwnProperty("data")
+            && response.data && response.data.hasOwnProperty("add_tag")
+            && !response.data.add_tag) {
+            swal({
+                title: "Tag already exists",
+                html: `The tag <strong>${tag}</strong> already exists.  Try again with a different name.`,
+                type: "warning"
+            });
+        } else {
+            document.querySelector(`label[for="new-tag-name"]`)!.classList.remove("mdc-textfield__label--float-above");
+            swal("Got it!", "Successfully created tag", "success");
 
-			// Clear form
-			tagInput.value = "";
-			tagStart.value = "";
-			tagEnd.value = "";
-			tagWarnDuplicates.checked = false;
-		}
+            // Clear form
+            tagInput.value = "";
+            tagStart.value = "";
+            tagEnd.value = "";
+            tagWarnDuplicates.checked = false;
+        }
 
-		button.disabled = false;
-	}).catch(error => {
-		console.error(error);
-		swal("Nah fam 🤚", "Unable to create new tag", "error");
-		button.disabled = false;	
-	});
+        button.disabled = false;
+    }).catch(error => {
+        console.error(error);
+        swal("Nah fam 🤚", "Unable to create new tag", "error");
+        button.disabled = false;
+    });
 });
 
 // Populate checkboxes for question names
 client.query<GQL.IQuery>({
-	query: gql`{ question_names }`
+    query: gql`{ question_names }`
 }).then(response => {
-	if (!response.data || !response.data.question_names) {
-		return;
-	}
-	let checkboxTemplate = <HTMLTemplateElement> document.getElementById("checkbox-item")!;
-	let checkboxContainer = document.getElementById("question-options")!;
-	let button = document.getElementById("button-row")!;
+    if (!response.data || !response.data.question_names) {
+        return;
+    }
+    let checkboxTemplate = <HTMLTemplateElement>document.getElementById("checkbox-item")!;
+    let checkboxContainer = document.getElementById("question-options")!;
+    let button = document.getElementById("button-row")!;
 
-	let question_names = response.data.question_names.map(name => name);
-	question_names = question_names.sort((a, b) => {
-		return a.localeCompare(b);
-	});
+    let question_names = response.data.question_names.map(name => name);
+    question_names = question_names.sort((a, b) => {
+        return a.localeCompare(b);
+    });
 
-	for (let curr of question_names) {
-		let node = document.importNode(checkboxTemplate.content, true) as DocumentFragment;
-		let input = node.querySelector("input") as HTMLInputElement;
-		let label = node.querySelector("label") as HTMLLabelElement;
-		input.id = curr;
-		input.value = curr;
-		label.htmlFor = curr;
-		label.textContent = curr;
-		checkboxContainer.insertBefore(node, button);
-	}	
+    for (let curr of question_names) {
+        let node = document.importNode(checkboxTemplate.content, true) as DocumentFragment;
+        let input = node.querySelector("input") as HTMLInputElement;
+        let label = node.querySelector("label") as HTMLLabelElement;
+        input.id = curr;
+        input.value = curr;
+        label.htmlFor = curr;
+        label.textContent = curr;
+        checkboxContainer.insertBefore(node, button);
+    }
 }).catch(error => {
-	console.error(error);
-	swal("Nah fam ✋", "Error fetching registration question names", "error");
+    console.error(error);
+    swal("Nah fam ✋", "Error fetching registration question names", "error");
 });
 
 // Toggle display of question checkboxes
 document.querySelector("#question-options-wrapper span")!.addEventListener("click", e => {
-	let elem = document.getElementById("question-options")!;
-	elem.style.display = elem.style.display == "none" ? "" : "none";
+    let elem = document.getElementById("question-options")!;
+    elem.style.display = elem.style.display == "none" ? "" : "none";
 });
 
 document.getElementById("update-question-options")!.addEventListener("click", e => {
-	loadAttendees();
+    loadAttendees();
 });
 
 // Toggle display of filters
 document.querySelector("#filters-wrapper span")!.addEventListener("click", e => {
-	let elem = document.getElementById("filters")!;
-	elem.style.display = elem.style.display == "none" ? "" : "none";
+    let elem = document.getElementById("filters")!;
+    elem.style.display = elem.style.display == "none" ? "" : "none";
 });
 
 document.getElementById("attending-filter")!.addEventListener("change", e => {
-	loadAttendees();
+    loadAttendees();
 });
 
 // Populate application branches select options
 client.query<GQL.IQuery>({
-	query: gql`{ application_branches }`
+    query: gql`{ application_branches }`
 }).then(response => {
-	let select = document.getElementById("branches-filter")!;
-	let branches = response.data.application_branches;
+    let select = document.getElementById("branches-filter")!;
+    let branches = response.data.application_branches;
 
-	for (let curr of branches) {
-		let option = document.createElement("option");
-		option.textContent = curr;
-		option.value = curr;
-		select.appendChild(option);
-	}	
+    for (let curr of branches) {
+        let option = document.createElement("option");
+        option.textContent = curr;
+        option.value = curr;
+        select.appendChild(option);
+    }
 }).catch(error => {
-	console.error(error);
-	swal("Nah fam ✋", "Error fetching registration application branches", "error");
+    console.error(error);
+    swal("Nah fam ✋", "Error fetching registration application branches", "error");
 });
 
 // Populate confirmation branch options
 client.query<GQL.IQuery>({
-	query: gql `{ confirmation_branches }`
+    query: gql`{ confirmation_branches }`
 }).then(response => {
-	let select = document.getElementById("confirmation-branches-filter")!;
-	let branches = response.data.confirmation_branches;
+    let select = document.getElementById("confirmation-branches-filter")!;
+    let branches = response.data.confirmation_branches;
 
-	for (let curr of branches) {
-		let option = document.createElement("option");
-		option.textContent = curr;
-		option.value = curr;
-		select.appendChild(option);
-	}	
+    for (let curr of branches) {
+        let option = document.createElement("option");
+        option.textContent = curr;
+        option.value = curr;
+        select.appendChild(option);
+    }
 }).catch(error => {
-	console.error(error);
-	swal("Nah fam ✋", "Error fetching registration confirmation branches", "error");
+    console.error(error);
+    swal("Nah fam ✋", "Error fetching registration confirmation branches", "error");
 });
 
 document.getElementById("branches-filter")!.addEventListener("change", e => {
-	loadAttendees();
+    loadAttendees();
 });
 
 document.getElementById("confirmation-branches-filter")!.addEventListener("change", e => {
-	loadAttendees();
+    loadAttendees();
 });
 
+//TODO: this should display last successful checkin info
 // Subscriptions for updating checked in/out
 const subscriptionQuery = gql`subscription {
-  tag_change {
-	user {
-	  id
-	  name
-	  email
-	}
-	tags {
-	  tag {
-		name
-	  }
-	  checked_in
-	  checked_in_by
-	  checked_in_date
-	}
-  }
+    tag_change {
+        user {
+            id
+            name
+            email
+        }
+        tags {
+            tag {
+                name
+            }
+            last_successful_checkin {
+                checked_in
+                checked_in_by
+                checked_in_date
+            }
+        }
+    }
 }`;
 
 client.subscribe({
-	query: subscriptionQuery,
+    query: subscriptionQuery,
 }).subscribe({
-	next (response: {data: GQL.ISubscription}) {
-		if (!response.data || !response.data.tag_change) {
-			return;
-		}
+    next(response: { data: GQL.ISubscription }) {
+        if (!response.data || !response.data.tag_change) {
+            return;
+        }
 
-		let attendee = response.data.tag_change;
+        let attendee = response.data.tag_change;
 
-		if (!States["checkin"].isDisplayed)
-			return;
+        if (!States["checkin"].isDisplayed)
+            return;
 
-		let tag = tagSelector.value;
+        let tag = tagSelector.value;
 
-		// Filter by the currently shown tag
-		let attendeeTags = attendee.tags.filter((t) => t.tag.name === tag);
-		let button = <HTMLButtonElement> document.querySelector(`#item-${attendee.user.id} > .actions > button`);
+        // Filter by the currently shown tag
+        let attendeeTags = attendee.tags.filter((t) => t.tag.name === tag);
+        let button = <HTMLButtonElement>document.querySelector(`#item-${attendee.user.id} > .actions > button`);
 
-		if (!button) {
-			// This attendee belongs to a tag that isn't currently being shown
-			// This message can safely be ignored; the user list will be updated when switching tags
-			return;
-		}
-		if (attendeeTags.length === 0) {
-			// Check if the currently displayed tag is the tag that was just updated
-			return;
-		}
-		let attendeeTag = attendeeTags[0];
-		let status = <HTMLSpanElement> document.querySelector(`#${button.parentElement!.parentElement!.id} > .actions > span.status`)!;
-
-		if (attendeeTag.checked_in) {
-			button.textContent = "Check out";
-			button.classList.add("checked-in");
-			if (attendeeTag.checked_in_date && attendeeTag.checked_in_by) {
-				status.innerHTML = statusFormatter(attendeeTag.checked_in_date, attendeeTag.checked_in_by);
-			} 
-		}
-		else {
-			button.textContent = "Check in";
-			button.classList.remove("checked-in");
-			status.textContent = "";
-		}
-	}
+        if (!button) {
+            // This attendee belongs to a tag that isn't currently being shown
+            // This message can safely be ignored; the user list will be updated when switching tags
+            return;
+        }
+        if (attendeeTags.length === 0) {
+            // Check if the currently displayed tag is the tag that was just updated
+            return;
+        }
+        let attendeeTag = attendeeTags[0];
+        let status = <HTMLSpanElement>document.querySelector(`#${button.parentElement!.parentElement!.id} > .actions > span.status`)!;
+        if (attendeeTag.last_successful_checkin) {
+            if (attendeeTag.last_successful_checkin.checked_in) {
+                button.textContent = "Check out";
+                button.classList.add("checked-in");
+                if (attendeeTag.last_successful_checkin.checked_in_date && attendeeTag.last_successful_checkin.checked_in_by) {
+                    status.innerHTML = statusFormatter(attendeeTag.last_successful_checkin.checked_in_date, attendeeTag.last_successful_checkin.checked_in_by);
+                }
+            } else {
+                button.textContent = "Check in";
+                button.classList.remove("checked-in");
+                status.textContent = "";
+            }
+        } else {
+            swal("Invalid server response", "A new check-in event was received, but the server didn't send back enough data to process it", "error");
+        }
+    }
 });
 
 attachUserDeleteHandlers();
 // Update check in relative times every minute the lazy way
 setInterval(() => {
-	if (States["checkin"].isDisplayed) {
-		loadAttendees();
-	}
+    if (States["checkin"].isDisplayed) {
+        loadAttendees();
+    }
 }, 1000 * 60);
 loadAttendees();

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -6,12 +6,12 @@ declare let moment: any;
 import {ApolloClient} from "apollo-client";
 import {split} from "apollo-link";
 import {createHttpLink} from "apollo-link-http";
-import {InMemoryCache} from 'apollo-cache-inmemory';
+import {InMemoryCache} from "apollo-cache-inmemory";
 import {WebSocketLink} from "apollo-link-ws";
 import {SubscriptionClient} from "subscriptions-transport-ws";
-import {getOperationAST} from 'graphql';
-import gql from 'graphql-tag';
-import swal from 'sweetalert2';
+import {getOperationAST} from "graphql";
+import gql from "graphql-tag";
+import swal from "sweetalert2";
 
 const httpLink = createHttpLink({
     uri: "/graphql",
@@ -152,7 +152,7 @@ function checkIn(e: Event) {
         mutation: mutation,
         variables: {
             user: id,
-            tag: tag,
+            tag,
             checkin: checkingIn
         }
     }).then(response => {
@@ -198,7 +198,7 @@ function attachUserDeleteHandlers() {
            swal({
                 title: `Delete ${username}?`,
                 html: `${extraWarn ? extraWarnMessage + "<br /><br />" : ""}<strong>${username}</strong> will be permanently deleted!`,
-                type: 'warning',
+                type: "warning",
                 showCancelButton: true,
                 confirmButtonText: "Delete",
                 focusCancel: true,

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -303,9 +303,6 @@ function loadAttendees(filter: string = queryField.value, checkedIn: string = ch
                 tag {
                     name
                 }
-                checked_in
-                checked_in_by
-                checked_in_date
                 last_successful_checkin {
                     checked_in
                     checked_in_by

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -201,6 +201,7 @@ function attachUserDeleteHandlers() {
                 type: 'warning',
                 showCancelButton: true,
                 confirmButtonText: "Delete",
+                focusCancel: true,
                 confirmButtonColor: "#dc3545"
             }).then(result => {
                 if (result.value) {

--- a/client/js/main.ts
+++ b/client/js/main.ts
@@ -169,7 +169,10 @@ function checkIn(e: Event) {
                 }
             }
             if (!checkin_success) {
-                swal("Glitch in the matrix", "Your local check-in data is out-of-date.  Please refresh the page to continue", "error");
+                swal({ title: "Glitch in the matrix",
+                    text: "Your local check-in data is out-of-date.  Please refresh the page to continue",
+                    type: "error",
+                    confirmButtonText: "Refresh" }).then(() => window.location.reload());
             }
         } else {
             swal("Empty server response", "The server didn't respond with the expected data", "error");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checkin2",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,8 +10,8 @@
       "integrity": "sha512-hfH2Oq3ikHu+zKE4b9kdGbzEqFiX+VxIg0nhgpY5iUgl975cAtTFhAdwfzr/jKdZhC9Ad5dE1CPrjEA+G7hzMg==",
       "dev": true,
       "requires": {
-        "@gql2ts/language-typescript": "1.9.0",
-        "@gql2ts/util": "1.9.0"
+        "@gql2ts/language-typescript": "^1.9.0",
+        "@gql2ts/util": "^1.9.0"
       }
     },
     "@gql2ts/from-schema": {
@@ -20,9 +20,9 @@
       "integrity": "sha512-zPJR2dAq3OlJklxajljLSSfyifjejbf/7O7ByANnJc/GMebVToBACG3yxacGMbgsy95gv6ZigJ1crgQhIIoDog==",
       "dev": true,
       "requires": {
-        "@gql2ts/language-typescript": "1.9.0",
-        "@gql2ts/util": "1.9.0",
-        "dedent": "0.7.0"
+        "@gql2ts/language-typescript": "^1.9.0",
+        "@gql2ts/util": "^1.9.0",
+        "dedent": "^0.7.0"
       }
     },
     "@gql2ts/language-typescript": {
@@ -31,8 +31,8 @@
       "integrity": "sha512-d3OlIFMjKoXH+VukXD7+pQRLgrP3NkXDQbCWSGonIl5mpRQ5aO5I8Fo53cMZQ9xCjj1Y5Vg24wtZOuY8spc6Ag==",
       "dev": true,
       "requires": {
-        "@gql2ts/util": "1.9.0",
-        "humps": "2.0.1"
+        "@gql2ts/util": "^1.9.0",
+        "humps": "^2.0.0"
       }
     },
     "@gql2ts/util": {
@@ -61,10 +61,10 @@
       "resolved": "https://registry.npmjs.org/@material/button/-/button-0.3.11.tgz",
       "integrity": "sha1-F6tM1dVTiePaNJaxwWJtzk9qeDk=",
       "requires": {
-        "@material/elevation": "0.1.13",
-        "@material/ripple": "0.8.8",
-        "@material/theme": "0.1.7",
-        "@material/typography": "0.3.0"
+        "@material/elevation": "^0.1.11",
+        "@material/ripple": "^0.8.2",
+        "@material/theme": "^0.1.7",
+        "@material/typography": "^0.3.0"
       },
       "dependencies": {
         "@material/ripple": {
@@ -72,8 +72,8 @@
           "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.8.8.tgz",
           "integrity": "sha1-Irie2eY4g/F/pPANEjcOMuDEWbc=",
           "requires": {
-            "@material/base": "0.2.6",
-            "@material/theme": "0.4.0"
+            "@material/base": "^0.2.6",
+            "@material/theme": "^0.4.0"
           },
           "dependencies": {
             "@material/theme": {
@@ -95,10 +95,10 @@
       "resolved": "https://registry.npmjs.org/@material/card/-/card-0.2.10.tgz",
       "integrity": "sha1-WaVT9EXAeivSpsOTkDFqHZwq8rE=",
       "requires": {
-        "@material/elevation": "0.1.13",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.4.0",
-        "@material/typography": "0.3.0"
+        "@material/elevation": "^0.1.13",
+        "@material/rtl": "^0.1.8",
+        "@material/theme": "^0.4.0",
+        "@material/typography": "^0.3.0"
       },
       "dependencies": {
         "@material/theme": {
@@ -118,11 +118,11 @@
       "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-0.3.7.tgz",
       "integrity": "sha1-USy0hkHwydaa9kRVDk7e+ucpSqw=",
       "requires": {
-        "@material/animation": "0.2.3",
-        "@material/base": "0.2.6",
-        "@material/ripple": "0.7.0",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.1.7"
+        "@material/animation": "^0.2.3",
+        "@material/base": "^0.2.1",
+        "@material/ripple": "^0.7.0",
+        "@material/rtl": "^0.1.6",
+        "@material/theme": "^0.1.5"
       },
       "dependencies": {
         "@material/ripple": {
@@ -130,8 +130,8 @@
           "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.7.0.tgz",
           "integrity": "sha1-6nhKbFT41JPT3yFEDc+rpwb7DKo=",
           "requires": {
-            "@material/base": "0.2.6",
-            "@material/theme": "0.1.7"
+            "@material/base": "^0.2.1",
+            "@material/theme": "^0.1.5"
           }
         }
       }
@@ -141,14 +141,14 @@
       "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-0.3.5.tgz",
       "integrity": "sha1-P09yTD5+JEUJ/U/+p7OHj1JjKfE=",
       "requires": {
-        "@material/animation": "0.3.1",
-        "@material/base": "0.2.6",
-        "@material/elevation": "0.1.13",
-        "@material/ripple": "0.8.8",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.1.7",
-        "@material/typography": "0.1.1",
-        "focus-trap": "2.4.6"
+        "@material/animation": "^0.3.1",
+        "@material/base": "^0.2.3",
+        "@material/elevation": "^0.1.11",
+        "@material/ripple": "^0.8.2",
+        "@material/rtl": "^0.1.7",
+        "@material/theme": "^0.1.7",
+        "@material/typography": "^0.1.1",
+        "focus-trap": "^2.3.0"
       },
       "dependencies": {
         "@material/animation": {
@@ -161,8 +161,8 @@
           "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.8.8.tgz",
           "integrity": "sha1-Irie2eY4g/F/pPANEjcOMuDEWbc=",
           "requires": {
-            "@material/base": "0.2.6",
-            "@material/theme": "0.4.0"
+            "@material/base": "^0.2.6",
+            "@material/theme": "^0.4.0"
           },
           "dependencies": {
             "@material/theme": {
@@ -184,12 +184,12 @@
       "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-0.5.9.tgz",
       "integrity": "sha1-gbgd9cjZXoKXrgUs/6ZtyZcBHb0=",
       "requires": {
-        "@material/animation": "0.4.1",
-        "@material/base": "0.2.6",
-        "@material/elevation": "0.1.13",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.4.0",
-        "@material/typography": "0.3.0"
+        "@material/animation": "^0.4.1",
+        "@material/base": "^0.2.6",
+        "@material/elevation": "^0.1.13",
+        "@material/rtl": "^0.1.8",
+        "@material/theme": "^0.4.0",
+        "@material/typography": "^0.3.0"
       },
       "dependencies": {
         "@material/animation": {
@@ -214,7 +214,7 @@
       "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-0.1.13.tgz",
       "integrity": "sha1-o4iF88r0OYymp0aMMIiH1wvUYFs=",
       "requires": {
-        "@material/animation": "0.4.1"
+        "@material/animation": "^0.4.1"
       },
       "dependencies": {
         "@material/animation": {
@@ -229,10 +229,10 @@
       "resolved": "https://registry.npmjs.org/@material/fab/-/fab-0.3.16.tgz",
       "integrity": "sha512-xiLEi6L7Ethhr/MJYfW/d6yMSNt7wBHswhZ+GOPBb/MQ7ODT6mSPknoNx9pE2IlQNdEY27+spijTcEpERzzJZg==",
       "requires": {
-        "@material/animation": "0.3.1",
-        "@material/elevation": "0.1.13",
-        "@material/ripple": "0.8.8",
-        "@material/theme": "0.2.0"
+        "@material/animation": "^0.3.1",
+        "@material/elevation": "^0.1.11",
+        "@material/ripple": "^0.8.5",
+        "@material/theme": "^0.2.0"
       },
       "dependencies": {
         "@material/animation": {
@@ -245,8 +245,8 @@
           "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.8.8.tgz",
           "integrity": "sha1-Irie2eY4g/F/pPANEjcOMuDEWbc=",
           "requires": {
-            "@material/base": "0.2.6",
-            "@material/theme": "0.4.0"
+            "@material/base": "^0.2.6",
+            "@material/theme": "^0.4.0"
           },
           "dependencies": {
             "@material/theme": {
@@ -268,11 +268,11 @@
       "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-0.2.17.tgz",
       "integrity": "sha1-fiomhJUWBxLA2W1EUwggCYpdylU=",
       "requires": {
-        "@material/base": "0.2.6",
-        "@material/rtl": "0.1.8",
-        "@material/selection-control": "0.1.3",
-        "@material/theme": "0.4.0",
-        "@material/typography": "0.3.0"
+        "@material/base": "^0.2.6",
+        "@material/rtl": "^0.1.8",
+        "@material/selection-control": "^0.1.3",
+        "@material/theme": "^0.4.0",
+        "@material/typography": "^0.3.0"
       },
       "dependencies": {
         "@material/theme": {
@@ -292,10 +292,10 @@
       "resolved": "https://registry.npmjs.org/@material/grid-list/-/grid-list-0.2.13.tgz",
       "integrity": "sha1-BM4ZjSPHEMZzFvHsXwQJgp/Wvq0=",
       "requires": {
-        "@material/base": "0.2.6",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.4.0",
-        "@material/typography": "0.3.0"
+        "@material/base": "^0.2.6",
+        "@material/rtl": "^0.1.8",
+        "@material/theme": "^0.4.0",
+        "@material/typography": "^0.3.0"
       },
       "dependencies": {
         "@material/theme": {
@@ -315,10 +315,10 @@
       "resolved": "https://registry.npmjs.org/@material/icon-toggle/-/icon-toggle-0.1.22.tgz",
       "integrity": "sha1-xsRJhR9rntKf83me5Vo0EICbiQ8=",
       "requires": {
-        "@material/animation": "0.4.1",
-        "@material/base": "0.2.6",
-        "@material/ripple": "0.8.8",
-        "@material/theme": "0.4.0"
+        "@material/animation": "^0.4.1",
+        "@material/base": "^0.2.6",
+        "@material/ripple": "^0.8.8",
+        "@material/theme": "^0.4.0"
       },
       "dependencies": {
         "@material/animation": {
@@ -331,8 +331,8 @@
           "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.8.8.tgz",
           "integrity": "sha1-Irie2eY4g/F/pPANEjcOMuDEWbc=",
           "requires": {
-            "@material/base": "0.2.6",
-            "@material/theme": "0.4.0"
+            "@material/base": "^0.2.6",
+            "@material/theme": "^0.4.0"
           }
         },
         "@material/theme": {
@@ -352,9 +352,9 @@
       "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-0.1.11.tgz",
       "integrity": "sha1-lx1OAVV1pLEx6W8KoMlECtXp4+8=",
       "requires": {
-        "@material/animation": "0.4.1",
-        "@material/base": "0.2.6",
-        "@material/theme": "0.4.0"
+        "@material/animation": "^0.4.1",
+        "@material/base": "^0.2.6",
+        "@material/theme": "^0.4.0"
       },
       "dependencies": {
         "@material/animation": {
@@ -374,10 +374,10 @@
       "resolved": "https://registry.npmjs.org/@material/list/-/list-0.2.20.tgz",
       "integrity": "sha1-XtSzG+OxnBrFwvRbi9iIW7VzdDQ=",
       "requires": {
-        "@material/ripple": "0.8.8",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.4.0",
-        "@material/typography": "0.3.0"
+        "@material/ripple": "^0.8.8",
+        "@material/rtl": "^0.1.8",
+        "@material/theme": "^0.4.0",
+        "@material/typography": "^0.3.0"
       },
       "dependencies": {
         "@material/ripple": {
@@ -385,8 +385,8 @@
           "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.8.8.tgz",
           "integrity": "sha1-Irie2eY4g/F/pPANEjcOMuDEWbc=",
           "requires": {
-            "@material/base": "0.2.6",
-            "@material/theme": "0.4.0"
+            "@material/base": "^0.2.6",
+            "@material/theme": "^0.4.0"
           }
         },
         "@material/theme": {
@@ -406,11 +406,11 @@
       "resolved": "https://registry.npmjs.org/@material/menu/-/menu-0.3.0.tgz",
       "integrity": "sha512-b8P4CaQ8MntizCy9v1+8aqq3m/ivb99fbR0CdQzv8aCumZW5/3hR3p4BpbNm0y5o+tJlXeX5MZDSOAvnVf3iVg==",
       "requires": {
-        "@material/animation": "0.2.3",
-        "@material/base": "0.2.6",
-        "@material/elevation": "0.1.13",
-        "@material/theme": "0.1.7",
-        "@material/typography": "0.2.3"
+        "@material/animation": "^0.2.3",
+        "@material/base": "^0.2.0",
+        "@material/elevation": "^0.1.8",
+        "@material/theme": "^0.1.5",
+        "@material/typography": "^0.2.2"
       }
     },
     "@material/radio": {
@@ -418,11 +418,11 @@
       "resolved": "https://registry.npmjs.org/@material/radio/-/radio-0.2.15.tgz",
       "integrity": "sha1-NZj3nL4cQTwrVKwysNsSlV+TY2s=",
       "requires": {
-        "@material/animation": "0.4.1",
-        "@material/base": "0.2.6",
-        "@material/ripple": "0.8.8",
-        "@material/selection-control": "0.1.3",
-        "@material/theme": "0.4.0"
+        "@material/animation": "^0.4.1",
+        "@material/base": "^0.2.6",
+        "@material/ripple": "^0.8.8",
+        "@material/selection-control": "^0.1.3",
+        "@material/theme": "^0.4.0"
       },
       "dependencies": {
         "@material/animation": {
@@ -435,8 +435,8 @@
           "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.8.8.tgz",
           "integrity": "sha1-Irie2eY4g/F/pPANEjcOMuDEWbc=",
           "requires": {
-            "@material/base": "0.2.6",
-            "@material/theme": "0.4.0"
+            "@material/base": "^0.2.6",
+            "@material/theme": "^0.4.0"
           }
         },
         "@material/theme": {
@@ -451,8 +451,8 @@
       "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.6.2.tgz",
       "integrity": "sha1-qFVtt8FB019VgsWZC+hpC++d7lk=",
       "requires": {
-        "@material/base": "0.2.6",
-        "@material/theme": "0.1.7"
+        "@material/base": "^0.2.0",
+        "@material/theme": "^0.1.5"
       }
     },
     "@material/rtl": {
@@ -465,13 +465,13 @@
       "resolved": "https://registry.npmjs.org/@material/select/-/select-0.3.18.tgz",
       "integrity": "sha1-YwHePHeudJ7e7bl90ja1WzDAozI=",
       "requires": {
-        "@material/animation": "0.4.1",
-        "@material/base": "0.2.6",
-        "@material/list": "0.2.20",
-        "@material/menu": "0.4.8",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.4.0",
-        "@material/typography": "0.3.0"
+        "@material/animation": "^0.4.1",
+        "@material/base": "^0.2.6",
+        "@material/list": "^0.2.20",
+        "@material/menu": "^0.4.8",
+        "@material/rtl": "^0.1.8",
+        "@material/theme": "^0.4.0",
+        "@material/typography": "^0.3.0"
       },
       "dependencies": {
         "@material/animation": {
@@ -484,11 +484,11 @@
           "resolved": "https://registry.npmjs.org/@material/menu/-/menu-0.4.8.tgz",
           "integrity": "sha1-YDtABdlpcOFUdPnSgj9MfKD1KHs=",
           "requires": {
-            "@material/animation": "0.4.1",
-            "@material/base": "0.2.6",
-            "@material/elevation": "0.1.13",
-            "@material/theme": "0.4.0",
-            "@material/typography": "0.3.0"
+            "@material/animation": "^0.4.1",
+            "@material/base": "^0.2.6",
+            "@material/elevation": "^0.1.13",
+            "@material/theme": "^0.4.0",
+            "@material/typography": "^0.3.0"
           }
         },
         "@material/theme": {
@@ -508,7 +508,7 @@
       "resolved": "https://registry.npmjs.org/@material/selection-control/-/selection-control-0.1.3.tgz",
       "integrity": "sha1-T7ftH9fuIpajLBVs8sHriSv+RMY=",
       "requires": {
-        "@material/ripple": "0.8.8"
+        "@material/ripple": "^0.8.8"
       },
       "dependencies": {
         "@material/ripple": {
@@ -516,8 +516,8 @@
           "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.8.8.tgz",
           "integrity": "sha1-Irie2eY4g/F/pPANEjcOMuDEWbc=",
           "requires": {
-            "@material/base": "0.2.6",
-            "@material/theme": "0.4.0"
+            "@material/base": "^0.2.6",
+            "@material/theme": "^0.4.0"
           }
         },
         "@material/theme": {
@@ -532,10 +532,10 @@
       "resolved": "https://registry.npmjs.org/@material/slider/-/slider-0.1.1.tgz",
       "integrity": "sha1-1GuxyAqVNIkszsn6CY4VG2mIYCM=",
       "requires": {
-        "@material/animation": "0.2.3",
-        "@material/base": "0.2.6",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.1.7"
+        "@material/animation": "^0.2.2",
+        "@material/base": "^0.2.1",
+        "@material/rtl": "^0.1.6",
+        "@material/theme": "^0.1.5"
       }
     },
     "@material/snackbar": {
@@ -543,12 +543,12 @@
       "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-0.2.2.tgz",
       "integrity": "sha1-ybKEE4bVWG+QNEtX+5wiBKifFqI=",
       "requires": {
-        "@material/animation": "0.2.3",
-        "@material/base": "0.2.6",
-        "@material/button": "0.3.11",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.1.7",
-        "@material/typography": "0.2.3"
+        "@material/animation": "^0.2.3",
+        "@material/base": "^0.2.1",
+        "@material/button": "^0.3.8",
+        "@material/rtl": "^0.1.6",
+        "@material/theme": "^0.1.5",
+        "@material/typography": "^0.2.2"
       }
     },
     "@material/switch": {
@@ -556,9 +556,9 @@
       "resolved": "https://registry.npmjs.org/@material/switch/-/switch-0.1.15.tgz",
       "integrity": "sha1-bysfHvfD3JbjKmijEBSYtWKRRhk=",
       "requires": {
-        "@material/animation": "0.4.1",
-        "@material/elevation": "0.1.13",
-        "@material/theme": "0.4.0"
+        "@material/animation": "^0.4.1",
+        "@material/elevation": "^0.1.13",
+        "@material/theme": "^0.4.0"
       },
       "dependencies": {
         "@material/animation": {
@@ -578,12 +578,12 @@
       "resolved": "https://registry.npmjs.org/@material/tabs/-/tabs-0.2.9.tgz",
       "integrity": "sha1-5RLSSKYrN+XtVwkMUuZhmWDr3bM=",
       "requires": {
-        "@material/animation": "0.3.1",
-        "@material/base": "0.2.6",
-        "@material/ripple": "0.8.8",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.3.1",
-        "@material/typography": "0.3.0"
+        "@material/animation": "^0.3.1",
+        "@material/base": "^0.2.5",
+        "@material/ripple": "^0.8.6",
+        "@material/rtl": "^0.1.7",
+        "@material/theme": "^0.3.0",
+        "@material/typography": "^0.3.0"
       },
       "dependencies": {
         "@material/animation": {
@@ -596,8 +596,8 @@
           "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.8.8.tgz",
           "integrity": "sha1-Irie2eY4g/F/pPANEjcOMuDEWbc=",
           "requires": {
-            "@material/base": "0.2.6",
-            "@material/theme": "0.4.0"
+            "@material/base": "^0.2.6",
+            "@material/theme": "^0.4.0"
           },
           "dependencies": {
             "@material/theme": {
@@ -624,11 +624,11 @@
       "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-0.2.11.tgz",
       "integrity": "sha512-k82nLd9H0QFLHYL6f/KKL0DnJakKXSCVm0G7zqU3t+7TaHqgIzHwHvLsSULtsCaIkKjlxXHTBeZmLv7DegH1Zg==",
       "requires": {
-        "@material/animation": "0.2.3",
-        "@material/base": "0.2.6",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.1.7",
-        "@material/typography": "0.2.3"
+        "@material/animation": "^0.2.3",
+        "@material/base": "^0.2.0",
+        "@material/rtl": "^0.1.5",
+        "@material/theme": "^0.1.5",
+        "@material/typography": "^0.2.2"
       }
     },
     "@material/theme": {
@@ -641,11 +641,11 @@
       "resolved": "https://registry.npmjs.org/@material/toolbar/-/toolbar-0.4.11.tgz",
       "integrity": "sha1-KEyKQ02bMWA+EDrFjR52vrGPqn4=",
       "requires": {
-        "@material/base": "0.2.6",
-        "@material/elevation": "0.1.13",
-        "@material/rtl": "0.1.8",
-        "@material/theme": "0.4.0",
-        "@material/typography": "0.3.0"
+        "@material/base": "^0.2.6",
+        "@material/elevation": "^0.1.13",
+        "@material/rtl": "^0.1.8",
+        "@material/theme": "^0.4.0",
+        "@material/typography": "^0.3.0"
       },
       "dependencies": {
         "@material/theme": {
@@ -677,7 +677,7 @@
       "integrity": "sha1-M8oUmPw35Rxd8MgcrjRWnnBB4CU=",
       "dev": true,
       "requires": {
-        "@types/express": "4.16.0"
+        "@types/express": "*"
       }
     },
     "@types/bson": {
@@ -686,7 +686,7 @@
       "integrity": "sha512-j+UcCWI+FsbI5/FQP/Kj2CXyplWAz39ktHFkXk84h7dNblKRSoNJs95PZFRd96NQGqsPEPgeclqnznWZr14ZDA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.29"
+        "@types/node": "*"
       }
     },
     "@types/caseless": {
@@ -713,7 +713,7 @@
       "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
       "dev": true,
       "requires": {
-        "@types/express": "4.16.0"
+        "@types/express": "*"
       }
     },
     "@types/cookie-parser": {
@@ -722,7 +722,7 @@
       "integrity": "sha512-iJY6B3ZGufLiDf2OCAgiAAQuj1sMKC/wz/7XCEjZ+/MDuultfFJuSwrBKcLSmJ5iYApLzCCYBYJZs0Ws8GPmwA==",
       "dev": true,
       "requires": {
-        "@types/express": "4.16.0"
+        "@types/express": "*"
       }
     },
     "@types/cookiejar": {
@@ -737,7 +737,7 @@
       "integrity": "sha512-c4kjQ7avmOV22T+xH2BAE/n4F52mGm+ELyHOk5PrGc/26Ps6RagP5lVKfDoLx+jmRnFKQlq6XIS33tp9Dco0Ug==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.29"
+        "@types/node": "*"
       }
     },
     "@types/escape-string-regexp": {
@@ -758,9 +758,9 @@
       "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
       "dev": true,
       "requires": {
-        "@types/body-parser": "0.0.33",
-        "@types/express-serve-static-core": "4.16.0",
-        "@types/serve-static": "1.13.2"
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
@@ -769,9 +769,9 @@
       "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
       "dev": true,
       "requires": {
-        "@types/events": "1.2.0",
-        "@types/node": "8.10.29",
-        "@types/range-parser": "1.2.2"
+        "@types/events": "*",
+        "@types/node": "*",
+        "@types/range-parser": "*"
       }
     },
     "@types/form-data": {
@@ -780,7 +780,7 @@
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.29"
+        "@types/node": "*"
       }
     },
     "@types/graphql": {
@@ -812,9 +812,9 @@
       "integrity": "sha512-ljS4mE9o3apEkI59pftdnLf3b1ZczMPtXWp1myrhR+E/CLk0O5SjbTt6Rn3OxMB+Qc2eAytrQVufa4y1pFqE2A==",
       "dev": true,
       "requires": {
-        "@types/bson": "1.0.11",
-        "@types/events": "1.2.0",
-        "@types/node": "8.10.29"
+        "@types/bson": "*",
+        "@types/events": "*",
+        "@types/node": "*"
       }
     },
     "@types/mongoose": {
@@ -823,9 +823,9 @@
       "integrity": "sha512-v0w2b/e++M6HgRcQq5Sriy7vClryJNDqxWbmhrnTJeG86TfhcweYxGfSwhG4kLORmzOpGYH4Y8/2ROxu5hsvdw==",
       "dev": true,
       "requires": {
-        "@types/events": "1.2.0",
-        "@types/mongodb": "3.1.7",
-        "@types/node": "8.10.29"
+        "@types/events": "*",
+        "@types/mongodb": "*",
+        "@types/node": "*"
       }
     },
     "@types/morgan": {
@@ -834,7 +834,7 @@
       "integrity": "sha512-E9qFi0seOkdlQnCTPv54brNfGWeFdRaEhI5tSue4pdx/V+xfxvMETsxXhOEcj1cYL+0n/jcTEmj/jD2gjzCwMg==",
       "dev": true,
       "requires": {
-        "@types/express": "4.16.0"
+        "@types/express": "*"
       }
     },
     "@types/multer": {
@@ -843,7 +843,7 @@
       "integrity": "sha1-+Jx1EifcILfJM8MJo+dGfEmfzew=",
       "dev": true,
       "requires": {
-        "@types/express": "4.16.0"
+        "@types/express": "*"
       }
     },
     "@types/node": {
@@ -870,10 +870,10 @@
       "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
       "dev": true,
       "requires": {
-        "@types/caseless": "0.12.1",
-        "@types/form-data": "2.2.1",
-        "@types/node": "8.10.29",
-        "@types/tough-cookie": "2.3.3"
+        "@types/caseless": "*",
+        "@types/form-data": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*"
       }
     },
     "@types/request-promise-native": {
@@ -882,7 +882,7 @@
       "integrity": "sha512-uYPjTChD9TpjlvbBjNpZfNc64TBejBS52u7pbxhQLnlxw+5Em7wLb6DU2wdJVhJ2Mou7v50N0qgL4Gia5mmRYg==",
       "dev": true,
       "requires": {
-        "@types/request": "2.47.1"
+        "@types/request": "*"
       }
     },
     "@types/serve-static": {
@@ -891,8 +891,8 @@
       "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.16.0",
-        "@types/mime": "2.0.0"
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "@types/superagent": {
@@ -901,8 +901,8 @@
       "integrity": "sha512-Dnh0Iw6NO55z1beXvlsvUrfk4cd9eL2nuTmUk+rAhSVCk10PGGFbqCCTwbau9D0d2W3DITiXl4z8VCqppGkMPQ==",
       "dev": true,
       "requires": {
-        "@types/cookiejar": "2.1.0",
-        "@types/node": "8.10.29"
+        "@types/cookiejar": "*",
+        "@types/node": "*"
       }
     },
     "@types/supertest": {
@@ -911,7 +911,7 @@
       "integrity": "sha512-qRvPP8dO7IBqJz8LaQ7/Lw2oo/geiDUPAMx/L+CQCkR9sN622O30XCH7RSyUmilyCSyjxyhJ7cEtd3hmwPwvhw==",
       "dev": true,
       "requires": {
-        "@types/superagent": "3.8.4"
+        "@types/superagent": "*"
       }
     },
     "@types/tough-cookie": {
@@ -926,7 +926,7 @@
       "integrity": "sha512-t5n0/iHoavnX1MqeYmKJgWc1W6yX4BXsNxQg7M5862RWrfN9S5k8yaWbDMGJSTCzbH7+q5QS8chjymd+ND9gMw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.29"
+        "@types/node": "*"
       }
     },
     "@types/zen-observable": {
@@ -940,8 +940,8 @@
       "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "accepts": {
@@ -949,7 +949,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.20",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -965,7 +965,7 @@
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3"
+        "acorn": "^5.0.0"
       }
     },
     "acorn-node": {
@@ -974,9 +974,9 @@
       "integrity": "sha512-krFKvw/d1F17AN3XZbybIUzEY4YEPNiGo05AfP3dBlfVKrMHETKpgjpuZkSF8qDNt9UkQcqj7am8yJLseklCMg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "acorn-dynamic-import": "3.0.0",
-        "xtend": "4.0.1"
+        "acorn": "^5.7.1",
+        "acorn-dynamic-import": "^3.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "ajv": {
@@ -984,10 +984,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ansi-regex": {
@@ -1001,7 +1001,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "apollo-cache": {
@@ -1009,7 +1009,7 @@
       "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.16.tgz",
       "integrity": "sha512-gVWKYyXF0SlpMyZ/i//AthzyPjjmAVYciEjwepLqMzIf0+7bzIwekpHDuzME8jf4XQepXcNNY571+BRyYHysmg==",
       "requires": {
-        "apollo-utilities": "1.0.20"
+        "apollo-utilities": "^1.0.20"
       }
     },
     "apollo-cache-control": {
@@ -1017,7 +1017,7 @@
       "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.1.1.tgz",
       "integrity": "sha512-XJQs167e9u+e5ybSi51nGYr70NPBbswdvTEHtbtXbwkZ+n9t0SLPvUcoqceayOSwjK1XYOdU/EKPawNdb3rLQA==",
       "requires": {
-        "graphql-extensions": "0.0.10"
+        "graphql-extensions": "^0.0.x"
       }
     },
     "apollo-cache-inmemory": {
@@ -1025,9 +1025,9 @@
       "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.2.9.tgz",
       "integrity": "sha512-Z4m4NpT2eboM4qUww/46CsjOyITavxrKPBrsCugDlmwSzonqMLZmAyZEQgnYXCj8L5q5epnOuf0sqyYK/6sGIQ==",
       "requires": {
-        "apollo-cache": "1.1.16",
-        "apollo-utilities": "1.0.20",
-        "graphql-anywhere": "4.1.18"
+        "apollo-cache": "^1.1.16",
+        "apollo-utilities": "^1.0.20",
+        "graphql-anywhere": "^4.1.18"
       }
     },
     "apollo-client": {
@@ -1036,13 +1036,13 @@
       "integrity": "sha512-E6pQD+BwI1zboM9oX83yzH9BmBjJWU5pL36CpGC2+XaaBDc6UvrPtacxQsg/h7Fq5T5IKJoIhuBEWtefJIb9xg==",
       "requires": {
         "@types/async": "2.0.49",
-        "@types/zen-observable": "0.8.0",
+        "@types/zen-observable": "^0.8.0",
         "apollo-cache": "1.1.16",
-        "apollo-link": "1.2.2",
-        "apollo-link-dedup": "1.0.9",
+        "apollo-link": "^1.0.0",
+        "apollo-link-dedup": "^1.0.0",
         "apollo-utilities": "1.0.20",
-        "symbol-observable": "1.2.0",
-        "zen-observable": "0.8.9"
+        "symbol-observable": "^1.0.2",
+        "zen-observable": "^0.8.0"
       }
     },
     "apollo-codegen": {
@@ -1051,16 +1051,16 @@
       "integrity": "sha512-F7I6yAzebukva9QyRLM5bcctV28U1+zdEzYsyB6rhBeFE4Es9Qop8im7XsejH5Nw/n6Do55oNC1+DcpU/bFMOg==",
       "dev": true,
       "requires": {
-        "change-case": "3.0.2",
-        "core-js": "2.5.7",
-        "glob": "7.1.3",
-        "graphql": "0.11.7",
-        "graphql-config": "1.2.1",
-        "inflected": "2.0.4",
-        "mkdirp": "0.5.1",
-        "node-fetch": "1.7.3",
-        "source-map-support": "0.4.18",
-        "yargs": "8.0.2"
+        "change-case": "^3.0.1",
+        "core-js": "^2.5.0",
+        "glob": "^7.1.2",
+        "graphql": "^0.11.3",
+        "graphql-config": "^1.0.5",
+        "inflected": "^2.0.2",
+        "mkdirp": "^0.5.1",
+        "node-fetch": "^1.7.2",
+        "source-map-support": "^0.4.15",
+        "yargs": "^8.0.2"
       },
       "dependencies": {
         "graphql": {
@@ -1084,7 +1084,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         }
       }
@@ -1095,8 +1095,8 @@
       "integrity": "sha512-Uk/BC09dm61DZRDSu52nGq0nFhq7mcBPTjy5EEH1eunJndtCaNXQhQz/BjkI2NdrfGI+B+i5he6YSoRBhYizdw==",
       "requires": {
         "@types/graphql": "0.12.6",
-        "apollo-utilities": "1.0.20",
-        "zen-observable-ts": "0.8.9"
+        "apollo-utilities": "^1.0.0",
+        "zen-observable-ts": "^0.8.9"
       }
     },
     "apollo-link-dedup": {
@@ -1104,7 +1104,7 @@
       "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.9.tgz",
       "integrity": "sha512-RbuEKpmSHVMtoREMPh2wUFTeh65q+0XPVeqgaOP/rGEAfvLyOMvX0vT2nVaejMohoMxuUnfZwpldXaDFWnlVbg==",
       "requires": {
-        "apollo-link": "1.2.2"
+        "apollo-link": "^1.2.2"
       }
     },
     "apollo-link-http": {
@@ -1112,8 +1112,8 @@
       "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.4.tgz",
       "integrity": "sha512-e9Ng3HfnW00Mh3TI6DhNRfozmzQOtKgdi+qUAsHBOEcTP0PTAmb+9XpeyEEOueLyO0GXhB92HUCIhzrWMXgwyg==",
       "requires": {
-        "apollo-link": "1.2.2",
-        "apollo-link-http-common": "0.2.4"
+        "apollo-link": "^1.2.2",
+        "apollo-link-http-common": "^0.2.4"
       }
     },
     "apollo-link-http-common": {
@@ -1121,7 +1121,7 @@
       "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.4.tgz",
       "integrity": "sha512-4j6o6WoXuSPen9xh4NBaX8/vL98X1xY2cYzUEK1F8SzvHe2oFONfxJBTekwU8hnvapcuq8Qh9Uct+gelu8T10g==",
       "requires": {
-        "apollo-link": "1.2.2"
+        "apollo-link": "^1.2.2"
       }
     },
     "apollo-link-ws": {
@@ -1129,7 +1129,7 @@
       "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.8.tgz",
       "integrity": "sha512-ucuGvr8CBBwCHl/Rbtyuv9Fn0FN5Qoyvy84KHtuMl2Uux2Sq+jt3bUum+pZ+hZntEd9k8M1OjrrXqRJ4PtEpyA==",
       "requires": {
-        "apollo-link": "1.2.2"
+        "apollo-link": "^1.2.2"
       }
     },
     "apollo-server-core": {
@@ -1137,9 +1137,9 @@
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-1.4.0.tgz",
       "integrity": "sha512-BP1Vh39krgEjkQxbjTdBURUjLHbFq1zeOChDJgaRsMxGtlhzuLWwwC6lLdPatN8jEPbeHq8Tndp9QZ3iQZOKKA==",
       "requires": {
-        "apollo-cache-control": "0.1.1",
-        "apollo-tracing": "0.1.4",
-        "graphql-extensions": "0.0.10"
+        "apollo-cache-control": "^0.1.0",
+        "apollo-tracing": "^0.1.0",
+        "graphql-extensions": "^0.0.x"
       }
     },
     "apollo-server-express": {
@@ -1147,8 +1147,8 @@
       "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-1.4.0.tgz",
       "integrity": "sha512-zkH00nxhLnJfO0HgnNPBTfZw8qI5ILaPZ5TecMCI9+Y9Ssr2b0bFr9pBRsXy9eudPhI+/O4yqegSUsnLdF/CPw==",
       "requires": {
-        "apollo-server-core": "1.4.0",
-        "apollo-server-module-graphiql": "1.4.0"
+        "apollo-server-core": "^1.4.0",
+        "apollo-server-module-graphiql": "^1.4.0"
       }
     },
     "apollo-server-module-graphiql": {
@@ -1161,7 +1161,7 @@
       "resolved": "http://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.1.4.tgz",
       "integrity": "sha512-Uv+1nh5AsNmC3m130i2u3IqbS+nrxyVV3KYimH5QKsdPjxxIQB3JAT+jJmpeDxBel8gDVstNmCh82QSLxLSIdQ==",
       "requires": {
-        "graphql-extensions": "0.0.10"
+        "graphql-extensions": "~0.0.9"
       }
     },
     "apollo-utilities": {
@@ -1169,7 +1169,7 @@
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.20.tgz",
       "integrity": "sha512-2M4BJCyX/9UXGJFoV4sTnVTZ4Q29aM18Z1avDrwvlCGGwoRTz50sGBAfTiWnUnnNQyPIIJEYElScw46DgIu0Rg==",
       "requires": {
-        "fast-json-stable-stringify": "2.0.0"
+        "fast-json-stable-stringify": "^2.0.0"
       }
     },
     "append-field": {
@@ -1183,7 +1183,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-filter": {
@@ -1214,7 +1214,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "asn1.js": {
@@ -1223,9 +1223,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -1270,7 +1270,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.10"
       }
     },
     "async-limiter": {
@@ -1331,7 +1331,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bluebird": {
@@ -1351,15 +1351,15 @@
       "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.16"
       }
     },
     "boolbase": {
@@ -1373,7 +1373,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1389,12 +1389,12 @@
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "combine-source-map": "0.8.0",
-        "defined": "1.0.0",
-        "safe-buffer": "5.1.2",
-        "through2": "2.0.3",
-        "umd": "3.0.3"
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
       }
     },
     "browser-resolve": {
@@ -1426,53 +1426,53 @@
       "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "assert": "1.4.1",
-        "browser-pack": "6.1.0",
-        "browser-resolve": "1.11.3",
-        "browserify-zlib": "0.2.0",
-        "buffer": "5.2.1",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.5.2",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "defined": "1.0.0",
-        "deps-sort": "2.0.0",
-        "domain-browser": "1.1.7",
-        "duplexer2": "0.1.4",
-        "events": "1.1.1",
-        "glob": "7.1.3",
-        "has": "1.0.3",
-        "htmlescape": "1.1.1",
-        "https-browserify": "1.0.0",
-        "inherits": "2.0.3",
-        "insert-module-globals": "7.2.0",
-        "labeled-stream-splicer": "2.0.1",
-        "module-deps": "4.1.1",
-        "os-browserify": "0.3.0",
-        "parents": "1.0.1",
-        "path-browserify": "0.0.1",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "read-only-stream": "2.0.0",
-        "readable-stream": "2.3.6",
-        "resolve": "1.8.1",
-        "shasum": "1.0.2",
-        "shell-quote": "1.6.1",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.3",
-        "string_decoder": "1.0.3",
-        "subarg": "1.0.0",
-        "syntax-error": "1.4.0",
-        "through2": "2.0.3",
-        "timers-browserify": "1.4.2",
-        "tty-browserify": "0.0.1",
-        "url": "0.11.0",
-        "util": "0.10.4",
-        "vm-browserify": "0.0.4",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^1.11.0",
+        "browserify-zlib": "~0.2.0",
+        "buffer": "^5.0.2",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "~1.5.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.0",
+        "domain-browser": "~1.1.0",
+        "duplexer2": "~0.1.2",
+        "events": "~1.1.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "^1.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.0.0",
+        "labeled-stream-splicer": "^2.0.0",
+        "module-deps": "^4.0.8",
+        "os-browserify": "~0.3.0",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^2.0.0",
+        "stream-http": "^2.0.0",
+        "string_decoder": "~1.0.0",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "~0.0.0",
+        "url": "~0.11.0",
+        "util": "~0.10.1",
+        "vm-browserify": "~0.0.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "concat-stream": {
@@ -1481,9 +1481,9 @@
           "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.0.6",
-            "typedarray": "0.0.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
           },
           "dependencies": {
             "readable-stream": {
@@ -1492,12 +1492,12 @@
               "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -1520,7 +1520,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1531,12 +1531,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -1545,9 +1545,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.2",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -1556,10 +1556,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-rsa": {
@@ -1568,8 +1568,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -1578,13 +1578,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.1",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.1"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -1593,7 +1593,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "bson": {
@@ -1607,8 +1607,8 @@
       "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.12"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -1640,7 +1640,7 @@
       "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
       "requires": {
         "dicer": "0.2.5",
-        "readable-stream": "1.1.14"
+        "readable-stream": "1.1.x"
       },
       "dependencies": {
         "isarray": {
@@ -1653,10 +1653,10 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1683,8 +1683,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -1704,9 +1704,9 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
       }
     },
     "chalk": {
@@ -1714,9 +1714,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "change-case": {
@@ -1725,24 +1725,24 @@
       "integrity": "sha512-Mww+SLF6MZ0U6kdg11algyKd5BARbyM4TbFBepwowYSR5ClfQGCGtxNXgykpN0uF/bstWeaGDT4JWaDh8zWAHA==",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.0",
-        "constant-case": "2.0.0",
-        "dot-case": "2.1.1",
-        "header-case": "1.0.1",
-        "is-lower-case": "1.1.3",
-        "is-upper-case": "1.1.2",
-        "lower-case": "1.1.4",
-        "lower-case-first": "1.0.2",
-        "no-case": "2.3.2",
-        "param-case": "2.1.1",
-        "pascal-case": "2.0.1",
-        "path-case": "2.1.1",
-        "sentence-case": "2.1.1",
-        "snake-case": "2.1.0",
-        "swap-case": "1.1.2",
-        "title-case": "2.1.1",
-        "upper-case": "1.1.3",
-        "upper-case-first": "1.1.2"
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.3.2",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "cheerio": {
@@ -1750,22 +1750,22 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.9.2",
-        "lodash.assignin": "4.2.0",
-        "lodash.bind": "4.2.1",
-        "lodash.defaults": "4.2.0",
-        "lodash.filter": "4.6.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.foreach": "4.5.0",
-        "lodash.map": "4.6.0",
-        "lodash.merge": "4.6.1",
-        "lodash.pick": "4.4.0",
-        "lodash.reduce": "4.6.0",
-        "lodash.reject": "4.6.0",
-        "lodash.some": "4.6.0"
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash.assignin": "^4.0.9",
+        "lodash.bind": "^4.1.4",
+        "lodash.defaults": "^4.0.1",
+        "lodash.filter": "^4.4.0",
+        "lodash.flatten": "^4.2.0",
+        "lodash.foreach": "^4.3.0",
+        "lodash.map": "^4.4.0",
+        "lodash.merge": "^4.4.0",
+        "lodash.pick": "^4.2.1",
+        "lodash.reduce": "^4.4.0",
+        "lodash.reject": "^4.4.0",
+        "lodash.some": "^4.4.0"
       }
     },
     "cipher-base": {
@@ -1774,8 +1774,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "cli-table": {
@@ -1792,9 +1792,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
         "string-width": {
@@ -1803,9 +1803,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -1845,10 +1845,10 @@
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.1.3",
-        "inline-source-map": "0.6.2",
-        "lodash.memoize": "3.0.4",
-        "source-map": "0.5.7"
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
       },
       "dependencies": {
         "source-map": {
@@ -1864,7 +1864,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -1883,7 +1883,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": ">= 1.34.0 < 2"
       }
     },
     "compression": {
@@ -1891,13 +1891,13 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
       "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "bytes": "3.0.0",
-        "compressible": "2.0.14",
+        "compressible": "~2.0.14",
         "debug": "2.6.9",
-        "on-headers": "1.0.1",
+        "on-headers": "~1.0.1",
         "safe-buffer": "5.1.2",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       }
     },
     "concat-map": {
@@ -1911,10 +1911,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "console-browserify": {
@@ -1923,7 +1923,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constant-case": {
@@ -1932,8 +1932,8 @@
       "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
       "dev": true,
       "requires": {
-        "snake-case": "2.1.0",
-        "upper-case": "1.1.3"
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
       }
     },
     "constants-browserify": {
@@ -1999,8 +1999,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.1"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -2009,11 +2009,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -2022,12 +2022,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-fetch": {
@@ -2054,9 +2054,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-browserify": {
@@ -2065,17 +2065,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.16",
-        "public-encrypt": "4.0.2",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "css-select": {
@@ -2083,10 +2083,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.1"
+        "nth-check": "~1.0.1"
       }
     },
     "css-what": {
@@ -2104,7 +2104,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-now": {
@@ -2177,10 +2177,10 @@
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "shasum": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "2.0.3"
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
       }
     },
     "des.js": {
@@ -2189,8 +2189,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -2204,8 +2204,8 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "defined": "1.0.0"
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
       }
     },
     "dicer": {
@@ -2213,7 +2213,7 @@
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "requires": {
-        "readable-stream": "1.1.14",
+        "readable-stream": "1.1.x",
         "streamsearch": "0.1.2"
       },
       "dependencies": {
@@ -2227,10 +2227,10 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2252,9 +2252,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dom-serializer": {
@@ -2262,8 +2262,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -2289,7 +2289,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -2297,8 +2297,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-case": {
@@ -2307,7 +2307,7 @@
       "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "duplexer2": {
@@ -2316,7 +2316,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.2"
       }
     },
     "ecc-jsbn": {
@@ -2325,8 +2325,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -2340,13 +2340,13 @@
       "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.5",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "encodeurl": {
@@ -2360,7 +2360,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.23"
+        "iconv-lite": "~0.4.13"
       }
     },
     "entities": {
@@ -2374,7 +2374,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es6-promise": {
@@ -2421,8 +2421,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.2"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "execa": {
@@ -2431,13 +2431,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "express": {
@@ -2445,36 +2445,36 @@
       "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.4",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "body-parser": {
@@ -2483,15 +2483,15 @@
           "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "http-errors": "1.6.3",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
             "iconv-lite": "0.4.19",
-            "on-finished": "2.3.0",
+            "on-finished": "~2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "1.6.16"
+            "type-is": "~1.6.15"
           }
         },
         "iconv-lite": {
@@ -2528,7 +2528,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": "1.4.0"
+                "statuses": ">= 1.3.1 < 2"
               }
             },
             "setprototypeof": {
@@ -2576,12 +2576,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "statuses": {
@@ -2597,7 +2597,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat": {
@@ -2605,7 +2605,7 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "requires": {
-        "is-buffer": "2.0.3"
+        "is-buffer": "~2.0.3"
       }
     },
     "focus-trap": {
@@ -2613,7 +2613,7 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-2.4.6.tgz",
       "integrity": "sha512-vWZTPtBU6pBoyWZDRZJHkXsyP2ZCZBHE3DRVXnSVdQKH/mcDtu9S5Kz8CUDyIqpfZfLEyI9rjKJLnc4Y40BRBg==",
       "requires": {
-        "tabbable": "1.1.3"
+        "tabbable": "^1.0.3"
       }
     },
     "forever-agent": {
@@ -2626,9 +2626,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.20"
+        "mime-types": "^2.1.12"
       }
     },
     "formidable": {
@@ -2653,8 +2653,8 @@
       "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0"
       }
     },
     "fs.realpath": {
@@ -2692,7 +2692,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -2701,12 +2701,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "gql2ts": {
@@ -2715,11 +2715,11 @@
       "integrity": "sha512-2ogiL6LjUWUZ5hvRCjZu13N8D1wxX0fuHs/psbJfbk5DM3bnUWAWcVi7v+wSkWIiukqJGUw6B+jkFGk7OtWKIQ==",
       "dev": true,
       "requires": {
-        "@gql2ts/from-query": "1.9.0",
-        "@gql2ts/from-schema": "1.9.0",
-        "@gql2ts/util": "1.9.0",
-        "commander": "2.17.1",
-        "graphql": "0.12.3"
+        "@gql2ts/from-query": "^1.9.0",
+        "@gql2ts/from-schema": "^1.9.0",
+        "@gql2ts/util": "^1.9.0",
+        "commander": "^2.9.0",
+        "graphql": ">= 0.10 <15"
       }
     },
     "graceful-fs": {
@@ -2747,7 +2747,7 @@
       "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.18.tgz",
       "integrity": "sha512-n0jsAEpGpQxsF0RDaxSjtEQdIP3tx2C3q++QuHYFyUl+4Npl5t64zFjWwO3ZhotxmTgs8zaSbZPVFpydn6k0dQ==",
       "requires": {
-        "apollo-utilities": "1.0.20"
+        "apollo-utilities": "^1.0.20"
       }
     },
     "graphql-config": {
@@ -2756,12 +2756,12 @@
       "integrity": "sha512-BOtbEOn/fD13jT0peCy3Fzp1DSTsA/1AcZp266AQ5Sk3wFndKCEa/H7donbu5UriOw1V/N1WDirYPnr7rd8E7Q==",
       "dev": true,
       "requires": {
-        "graphql": "0.12.3",
-        "graphql-import": "0.4.5",
-        "graphql-request": "1.8.2",
-        "js-yaml": "3.12.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4"
+        "graphql": "^0.12.3",
+        "graphql-import": "^0.4.0",
+        "graphql-request": "^1.4.0",
+        "js-yaml": "^3.10.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4"
       }
     },
     "graphql-extensions": {
@@ -2769,8 +2769,8 @@
       "resolved": "http://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.0.10.tgz",
       "integrity": "sha512-TnQueqUDCYzOSrpQb3q1ngDSP2otJSF+9yNLrQGPzkMsvnQ+v6e2d5tl+B35D4y+XpmvVnAn4T3ZK28mkILveA==",
       "requires": {
-        "core-js": "2.5.7",
-        "source-map-support": "0.5.9"
+        "core-js": "^2.5.3",
+        "source-map-support": "^0.5.1"
       }
     },
     "graphql-import": {
@@ -2779,7 +2779,7 @@
       "integrity": "sha512-G/+I08Qp6/QGTb9qapknCm3yPHV0ZL7wbaalWFpxsfR8ZhZoTBe//LsbsCKlbALQpcMegchpJhpTSKiJjhaVqQ==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.4"
       }
     },
     "graphql-request": {
@@ -2796,7 +2796,7 @@
       "resolved": "https://registry.npmjs.org/graphql-server-express/-/graphql-server-express-1.4.0.tgz",
       "integrity": "sha512-KdFI03IhogEDmH0QMUeG8lpGe+yR+M+9HDNAiHrkt8QD/1PbHDqlYxZ5hY/mR9Mzk4O3bRcsRkYIm+UrvX4HMA==",
       "requires": {
-        "apollo-server-express": "1.4.0"
+        "apollo-server-express": "^1.4.0"
       }
     },
     "graphql-subscriptions": {
@@ -2804,7 +2804,7 @@
       "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-0.5.8.tgz",
       "integrity": "sha512-0CaZnXKBw2pwnIbvmVckby5Ge5e2ecmjofhYCdyeACbCly2j3WXDP/pl+s+Dqd2GQFC7y99NB+53jrt55CKxYQ==",
       "requires": {
-        "iterall": "1.2.2"
+        "iterall": "^1.2.1"
       },
       "dependencies": {
         "iterall": {
@@ -2824,23 +2824,24 @@
       "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-2.24.0.tgz",
       "integrity": "sha512-Mz9I7jyizrd+RafC/5EogJKTVzBbIddDCrW0sP5QLmsVVM3ujfhqVYu2lEXOaJW8Sy18f3ZICHirmKcn6oMAcA==",
       "requires": {
-        "apollo-link": "1.2.2",
-        "apollo-utilities": "1.0.20",
-        "deprecated-decorator": "0.1.6",
-        "iterall": "1.1.3",
-        "uuid": "3.3.2"
+        "apollo-link": "^1.2.1",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
       }
     },
     "graphql-typewriter": {
       "version": "git://github.com/illegalprime/graphql-typewriter.git#6c9e4c7490256cc1fcac7af32f18d471c0b375ca",
+      "from": "git://github.com/illegalprime/graphql-typewriter.git#hacks",
       "dev": true,
       "requires": {
-        "commander": "2.17.1",
-        "glob": "7.1.3",
-        "graphql": "0.10.5",
-        "graphql-subscriptions": "0.4.4",
-        "graphql-tools": "1.2.3",
-        "m-io": "0.5.0"
+        "commander": "^2.11.0",
+        "glob": "^7.1.2",
+        "graphql": "^0.10.5",
+        "graphql-subscriptions": "^0.4.4",
+        "graphql-tools": "^1.1.0",
+        "m-io": "^0.5.0"
       },
       "dependencies": {
         "@types/graphql": {
@@ -2893,10 +2894,10 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
       "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "requires": {
-        "async": "2.6.1",
-        "optimist": "0.6.1",
-        "source-map": "0.6.1",
-        "uglify-js": "3.4.9"
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       }
     },
     "har-schema": {
@@ -2909,8 +2910,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.3.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -2919,7 +2920,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -2933,8 +2934,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -2943,8 +2944,8 @@
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "he": {
@@ -2959,8 +2960,8 @@
       "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
       }
     },
     "hmac-drbg": {
@@ -2969,9 +2970,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.5",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -2991,12 +2992,12 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.2",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-errors": {
@@ -3004,10 +3005,10 @@
       "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-signature": {
@@ -3015,9 +3016,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -3037,7 +3038,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {
@@ -3064,8 +3065,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -3079,7 +3080,7 @@
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "~0.5.3"
       },
       "dependencies": {
         "source-map": {
@@ -3096,16 +3097,16 @@
       "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "acorn-node": "1.5.2",
-        "combine-source-map": "0.8.0",
-        "concat-stream": "1.6.2",
-        "is-buffer": "1.1.6",
-        "path-is-absolute": "1.0.1",
-        "process": "0.11.10",
-        "through2": "2.0.3",
-        "undeclared-identifiers": "1.1.2",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "acorn-node": "^1.5.2",
+        "combine-source-map": "^0.8.0",
+        "concat-stream": "^1.6.1",
+        "is-buffer": "^1.1.0",
+        "path-is-absolute": "^1.0.1",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "undeclared-identifiers": "^1.1.2",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "is-buffer": {
@@ -3144,7 +3145,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -3153,7 +3154,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-lower-case": {
@@ -3162,7 +3163,7 @@
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.0"
       }
     },
     "is-stream": {
@@ -3182,7 +3183,7 @@
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "dev": true,
       "requires": {
-        "upper-case": "1.1.3"
+        "upper-case": "^1.1.0"
       }
     },
     "isarray": {
@@ -3212,8 +3213,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -3238,7 +3239,7 @@
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -3251,16 +3252,16 @@
       "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-3.11.5.tgz",
       "integrity": "sha512-ORsw84BuRKMLxfI+HFZuvxRDnsJps53D5fIGr6tLn4ZY+ymcG8XU00E+JJ2wfAiHx5w2QRNmOLE8xHiGAeSfuQ==",
       "requires": {
-        "cli-table": "0.3.1",
-        "commander": "2.17.1",
-        "debug": "3.2.5",
-        "flat": "4.1.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.get": "4.4.2",
-        "lodash.set": "4.3.2",
-        "lodash.uniq": "4.5.0",
-        "path-is-absolute": "1.0.1"
+        "cli-table": "^0.3.1",
+        "commander": "^2.8.1",
+        "debug": "^3.1.0",
+        "flat": "^4.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.get": "^4.4.0",
+        "lodash.set": "^4.3.0",
+        "lodash.uniq": "^4.5.0",
+        "path-is-absolute": "^1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -3268,7 +3269,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
           "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -3286,11 +3287,11 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -3327,9 +3328,9 @@
       "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "isarray": "2.0.4",
-        "stream-splicer": "2.0.0"
+        "inherits": "^2.0.1",
+        "isarray": "^2.0.4",
+        "stream-splicer": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -3346,7 +3347,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "load-json-file": {
@@ -3355,10 +3356,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -3367,8 +3368,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -3382,8 +3383,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -3431,9 +3432,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.defaults": {
@@ -3479,9 +3480,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.map": {
@@ -3542,7 +3543,7 @@
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.2"
       }
     },
     "lru-cache": {
@@ -3551,8 +3552,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "m-io": {
@@ -3561,8 +3562,8 @@
       "integrity": "sha1-chuybdjUN13Oy1bY3AFm64vp0AM=",
       "dev": true,
       "requires": {
-        "fs-extra": "2.1.2",
-        "q": "1.5.1"
+        "fs-extra": "^2.0.0",
+        "q": "^1.4.1"
       }
     },
     "material-components-web": {
@@ -3570,34 +3571,34 @@
       "resolved": "https://registry.npmjs.org/material-components-web/-/material-components-web-0.13.0.tgz",
       "integrity": "sha512-bcxvuEqP60ziZwcoePTdHBYzX/NkWKmTPztw2zTPbHyAMqDrScNJsDVC6AJKNKcGnpMA6jhwSsWQer9fabM7+g==",
       "requires": {
-        "@material/animation": "0.2.3",
-        "@material/auto-init": "0.1.4",
-        "@material/base": "0.2.6",
-        "@material/button": "0.3.11",
-        "@material/card": "0.2.10",
-        "@material/checkbox": "0.3.7",
-        "@material/dialog": "0.3.5",
-        "@material/drawer": "0.5.9",
-        "@material/elevation": "0.1.13",
-        "@material/fab": "0.3.16",
-        "@material/form-field": "0.2.17",
-        "@material/grid-list": "0.2.13",
-        "@material/icon-toggle": "0.1.22",
-        "@material/layout-grid": "0.2.0",
-        "@material/linear-progress": "0.1.11",
-        "@material/list": "0.2.20",
-        "@material/menu": "0.3.0",
-        "@material/radio": "0.2.15",
-        "@material/ripple": "0.6.2",
-        "@material/select": "0.3.18",
-        "@material/slider": "0.1.1",
-        "@material/snackbar": "0.2.2",
-        "@material/switch": "0.1.15",
-        "@material/tabs": "0.2.9",
-        "@material/textfield": "0.2.11",
-        "@material/theme": "0.1.7",
-        "@material/toolbar": "0.4.11",
-        "@material/typography": "0.2.3"
+        "@material/animation": "^0.2.3",
+        "@material/auto-init": "^0.1.2",
+        "@material/base": "^0.2.0",
+        "@material/button": "^0.3.7",
+        "@material/card": "^0.2.3",
+        "@material/checkbox": "^0.3.6",
+        "@material/dialog": "^0.3.1",
+        "@material/drawer": "^0.5.0",
+        "@material/elevation": "^0.1.8",
+        "@material/fab": "^0.3.9",
+        "@material/form-field": "^0.2.7",
+        "@material/grid-list": "^0.2.4",
+        "@material/icon-toggle": "^0.1.12",
+        "@material/layout-grid": "^0.2.0",
+        "@material/linear-progress": "^0.1.2",
+        "@material/list": "^0.2.10",
+        "@material/menu": "^0.3.0",
+        "@material/radio": "^0.2.5",
+        "@material/ripple": "^0.6.2",
+        "@material/select": "^0.3.8",
+        "@material/slider": "^0.1.0",
+        "@material/snackbar": "^0.2.1",
+        "@material/switch": "^0.1.8",
+        "@material/tabs": "^0.2.1",
+        "@material/textfield": "^0.2.11",
+        "@material/theme": "^0.1.5",
+        "@material/toolbar": "^0.4.0",
+        "@material/typography": "^0.2.2"
       }
     },
     "md5.js": {
@@ -3606,8 +3607,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "media-typer": {
@@ -3621,7 +3622,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "merge-descriptors": {
@@ -3640,8 +3641,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -3659,7 +3660,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": "~1.36.0"
       }
     },
     "mimic-fn": {
@@ -3686,7 +3687,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -3735,7 +3736,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "debug": {
@@ -3753,12 +3754,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -3773,7 +3774,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -3784,21 +3785,21 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "browser-resolve": "1.11.3",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.5.2",
-        "defined": "1.0.0",
-        "detective": "4.7.1",
-        "duplexer2": "0.1.4",
-        "inherits": "2.0.3",
-        "parents": "1.0.1",
-        "readable-stream": "2.3.6",
-        "resolve": "1.8.1",
-        "stream-combiner2": "1.1.1",
-        "subarg": "1.0.0",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "browser-resolve": "^1.7.0",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "~1.5.0",
+        "defined": "^1.0.0",
+        "detective": "^4.0.0",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.3",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "concat-stream": {
@@ -3807,9 +3808,9 @@
           "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.0.6",
-            "typedarray": "0.0.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
           },
           "dependencies": {
             "readable-stream": {
@@ -3818,12 +3819,12 @@
               "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
               }
             }
           }
@@ -3848,7 +3849,7 @@
       "integrity": "sha512-BGUxo4a/p5KtZpOn6+z6iZXTHfDxKDvibHQap9uMJqQouwoszvTIO/QbVZkaSX3Spny0jtTEeHc0FwfpGbtEzA==",
       "requires": {
         "mongodb-core": "3.1.3",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.2"
       }
     },
     "mongodb-core": {
@@ -3856,10 +3857,10 @@
       "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.3.tgz",
       "integrity": "sha512-dISiV3zHGJTwZpg0xDhi9zCqFGMhA5kDPByHlcaEp09NSKfzHJ7XQbqVrL7qhki1U9PZHsmRfbFzco+6b1h2wA==",
       "requires": {
-        "bson": "1.1.0",
-        "require_optional": "1.0.1",
-        "safe-buffer": "5.1.2",
-        "saslprep": "1.0.1"
+        "bson": "^1.1.0",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
       },
       "dependencies": {
         "bson": {
@@ -3875,7 +3876,7 @@
       "integrity": "sha512-0wRX2+08Fvx3iUWX2o33mDPLUsjR0HBFInwwclpfZVAb7Ps63XhYpkjQkqDMmHb7LNl6QVsRhdUIC47cU4EAPg==",
       "requires": {
         "async": "2.6.1",
-        "bson": "1.0.9",
+        "bson": "~1.0.5",
         "kareem": "2.2.1",
         "lodash.get": "4.4.2",
         "mongodb": "3.1.4",
@@ -3899,11 +3900,11 @@
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
       "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
       "requires": {
-        "basic-auth": "2.0.0",
+        "basic-auth": "~2.0.0",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
+        "depd": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
       }
     },
     "mpath": {
@@ -3943,14 +3944,14 @@
       "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.1.tgz",
       "integrity": "sha512-JHdEoxkA/5NgZRo91RNn4UT+HdcJV9XUo01DTkKC7vo1erNIngtuaw9Y0WI8RdTlyi+wMIbunflhghzVLuGJyw==",
       "requires": {
-        "append-field": "0.1.0",
-        "busboy": "0.2.14",
-        "concat-stream": "1.6.2",
-        "mkdirp": "0.5.1",
-        "object-assign": "3.0.0",
-        "on-finished": "2.3.0",
-        "type-is": "1.6.16",
-        "xtend": "4.0.1"
+        "append-field": "^0.1.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^3.0.0",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
       }
     },
     "negotiator": {
@@ -3964,7 +3965,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-fetch": {
@@ -3973,8 +3974,8 @@
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "normalize-package-data": {
@@ -3983,10 +3984,3039 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.7.0.tgz",
+      "integrity": "sha512-OtxCLzx+pcsjMGrjZpBp214ZjxzHcAe3zLYIlaVpRYqFHff6bgggyTLf2OZPO8lfxN0RHLJnFFUU016JCzM/Ww==",
+      "requires": {
+        "JSONStream": "^1.3.5",
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "^2.0.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.2",
+        "bluebird": "^3.5.3",
+        "byte-size": "^5.0.1",
+        "cacache": "^11.3.2",
+        "call-limit": "~1.1.0",
+        "chownr": "^1.1.1",
+        "ci-info": "^2.0.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.5.1",
+        "cmd-shim": "~2.0.2",
+        "columnify": "~1.5.4",
+        "config-chain": "^1.1.12",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "figgy-pudding": "^3.5.1",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.0.1",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.7.1",
+        "iferr": "^1.0.2",
+        "imurmurhash": "*",
+        "inflight": "~1.0.6",
+        "inherits": "~2.0.3",
+        "ini": "^1.3.5",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "^3.0.0",
+        "json-parse-better-errors": "^1.0.2",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^3.0.3",
+        "libnpm": "^2.0.1",
+        "libnpmaccess": "*",
+        "libnpmhook": "^5.0.2",
+        "libnpmorg": "*",
+        "libnpmsearch": "*",
+        "libnpmteam": "*",
+        "libnpx": "^10.2.0",
+        "lock-verify": "^2.0.2",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^4.1.5",
+        "meant": "~1.0.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "~0.5.1",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^3.8.0",
+        "nopt": "~4.0.1",
+        "normalize-package-data": "~2.4.0",
+        "npm-audit-report": "^1.3.2",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "~3.0.0",
+        "npm-lifecycle": "^2.1.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "^1.2.0",
+        "npm-pick-manifest": "^2.2.3",
+        "npm-profile": "*",
+        "npm-registry-fetch": "^3.8.0",
+        "npm-user-validate": "~1.0.0",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "^1.5.1",
+        "osenv": "^0.1.5",
+        "pacote": "^9.4.0",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.2.0",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "~1.0.1",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.0.13",
+        "read-package-tree": "^5.2.1",
+        "readable-stream": "^3.1.1",
+        "readdir-scoped-modules": "*",
+        "request": "^2.88.0",
+        "retry": "^0.12.0",
+        "rimraf": "^2.6.3",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.6.0",
+        "sha": "~2.0.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^6.0.1",
+        "stringify-package": "^1.0.0",
+        "tar": "^4.4.8",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "uid-number": "0.0.6",
+        "umask": "~1.1.0",
+        "unique-filename": "^1.1.1",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.3.2",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^1.3.1",
+        "worker-farm": "^1.6.0",
+        "write-file-atomic": "^2.4.2"
+      },
+      "dependencies": {
+        "JSONStream": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
+          }
+        },
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "agent-base": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "agentkeepalive": {
+          "version": "3.4.1",
+          "bundled": true,
+          "requires": {
+            "humanize-ms": "^1.2.1"
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "bundled": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "ansicolors": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "ansistyles": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "bin-links": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.5.0",
+            "cmd-shim": "^2.0.2",
+            "gentle-fs": "^2.0.0",
+            "graceful-fs": "^4.1.11",
+            "write-file-atomic": "^2.3.0"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "~2.0.0"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.3",
+          "bundled": true
+        },
+        "boxen": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-from": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtins": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "byline": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "byte-size": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "cacache": {
+          "version": "11.3.2",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.5.3",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
+          },
+          "dependencies": {
+            "chownr": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "lru-cache": {
+              "version": "5.1.1",
+              "bundled": true,
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            },
+            "unique-filename": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "unique-slug": "^2.0.0"
+              }
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "call-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "capture-stack-trace": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "cidr-regex": {
+          "version": "2.0.10",
+          "bundled": true,
+          "requires": {
+            "ip-regex": "^2.1.0"
+          }
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cli-columns": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "cli-table3": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^2.1.1"
+          }
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "clone": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "cmd-shim": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
+          }
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "^1.1.1"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "colors": {
+          "version": "1.3.3",
+          "bundled": true,
+          "optional": true
+        },
+        "columnify": {
+          "version": "1.5.4",
+          "bundled": true,
+          "requires": {
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "config-chain": {
+          "version": "1.1.12",
+          "bundled": true,
+          "requires": {
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
+          }
+        },
+        "configstore": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "copy-concurrently": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "capture-stack-trace": "^1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cyclist": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "debuglog": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "clone": "^1.0.2"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "asap": "^2.0.0",
+            "wrappy": "1"
+          }
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        },
+        "dotenv": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "duplexify": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "editor": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "err-code": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "prr": "~1.0.1"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.4",
+          "bundled": true
+        },
+        "es6-promisify": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "es6-promise": "^4.0.3"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "figgy-pudding": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "find-npm-prefix": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "flush-write-stream": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "from2": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs-vacuum": {
+          "version": "1.2.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
+          },
+          "dependencies": {
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "genfun": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "gentle-fs": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.2",
+            "fs-vacuum": "^1.2.10",
+            "graceful-fs": "^4.1.11",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "path-is-inside": "^1.0.2",
+            "read-cmd-shim": "^1.0.1",
+            "slide": "^1.1.6"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "ini": "^1.3.4"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "bundled": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true
+        },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "bundled": true
+        },
+        "http-proxy-agent": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "agent-base": "4",
+            "debug": "3.1.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
+          }
+        },
+        "humanize-ms": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "ms": "^2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "iferr": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "import-lazy": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "init-package-json": {
+          "version": "1.10.3",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.1",
+            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "ip-regex": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-ci": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ci-info": "^1.0.0"
+          },
+          "dependencies": {
+            "ci-info": {
+              "version": "1.6.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-cidr": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "cidr-regex": "^2.0.10"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "package-json": "^4.0.0"
+          }
+        },
+        "lazy-property": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "libcipm": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.5.1",
+            "find-npm-prefix": "^1.0.2",
+            "graceful-fs": "^4.1.11",
+            "ini": "^1.3.5",
+            "lock-verify": "^2.0.2",
+            "mkdirp": "^0.5.1",
+            "npm-lifecycle": "^2.0.3",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "pacote": "^9.1.0",
+            "read-package-json": "^2.0.13",
+            "rimraf": "^2.6.2",
+            "worker-farm": "^1.6.0"
+          }
+        },
+        "libnpm": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.3",
+            "find-npm-prefix": "^1.0.2",
+            "libnpmaccess": "^3.0.1",
+            "libnpmconfig": "^1.2.1",
+            "libnpmhook": "^5.0.2",
+            "libnpmorg": "^1.0.0",
+            "libnpmpublish": "^1.1.0",
+            "libnpmsearch": "^2.0.0",
+            "libnpmteam": "^1.0.1",
+            "lock-verify": "^2.0.2",
+            "npm-lifecycle": "^2.1.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "npm-profile": "^4.0.1",
+            "npm-registry-fetch": "^3.8.0",
+            "npmlog": "^4.1.2",
+            "pacote": "^9.2.3",
+            "read-package-json": "^2.0.13",
+            "stringify-package": "^1.0.0"
+          }
+        },
+        "libnpmaccess": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "get-stream": "^4.0.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^3.8.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "libnpmconfig": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "find-up": "^3.0.0",
+            "ini": "^1.3.5"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "libnpmhook": {
+          "version": "5.0.2",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "libnpmpublish": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "lodash.clonedeep": "^4.5.0",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^3.8.0",
+            "semver": "^5.5.1",
+            "ssri": "^6.0.1"
+          }
+        },
+        "libnpmsearch": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          }
+        },
+        "libnpmteam": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "libnpx": {
+          "version": "10.2.0",
+          "bundled": true,
+          "requires": {
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^11.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lock-verify": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "npm-package-arg": "^5.1.2 || 6",
+            "semver": "^5.4.1"
+          }
+        },
+        "lockfile": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "lodash._baseindexof": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "lodash._baseuniq": {
+          "version": "4.6.0",
+          "bundled": true,
+          "requires": {
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "lodash._cacheindexof": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "lodash._createcache": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0"
+          }
+        },
+        "lodash._createset": {
+          "version": "4.0.3",
+          "bundled": true
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash._root": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "bundled": true
+        },
+        "lodash.union": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.without": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "make-fetch-happen": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "agentkeepalive": "^3.4.1",
+            "cacache": "^11.0.1",
+            "http-cache-semantics": "^3.8.1",
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.1",
+            "lru-cache": "^4.1.2",
+            "mississippi": "^3.0.0",
+            "node-fetch-npm": "^2.0.2",
+            "promise-retry": "^1.1.1",
+            "socks-proxy-agent": "^4.0.0",
+            "ssri": "^6.0.0"
+          }
+        },
+        "meant": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.35.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.19",
+          "bundled": true,
+          "requires": {
+            "mime-db": "~1.35.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "minizlib": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "node-fetch-npm": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "json-parse-better-errors": "^1.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "node-gyp": {
+          "version": "3.8.0",
+          "bundled": true,
+          "requires": {
+            "fstream": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "^2.87.0",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^2.0.0",
+            "which": "1"
+          },
+          "dependencies": {
+            "nopt": {
+              "version": "3.0.6",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1"
+              }
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "npm-audit-report": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "cli-table3": "^0.5.0",
+            "console-control-strings": "^1.1.0"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "npm-cache-filename": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "npm-install-checks": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "semver": "^2.3.0 || 3.x || 4 || 5"
+          }
+        },
+        "npm-lifecycle": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "byline": "^5.0.0",
+            "graceful-fs": "^4.1.11",
+            "node-gyp": "^3.8.0",
+            "resolve-from": "^4.0.0",
+            "slide": "^1.1.6",
+            "uid-number": "0.0.6",
+            "umask": "^1.1.0",
+            "which": "^1.3.1"
+          }
+        },
+        "npm-logical-tree": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "npm-package-arg": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.6.0",
+            "osenv": "^0.1.5",
+            "semver": "^5.5.0",
+            "validate-npm-package-name": "^3.0.0"
+          }
+        },
+        "npm-packlist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npm-pick-manifest": {
+          "version": "2.2.3",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "npm-package-arg": "^6.0.0",
+            "semver": "^5.4.1"
+          }
+        },
+        "npm-profile": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.2 || 2",
+            "figgy-pudding": "^3.4.1",
+            "npm-registry-fetch": "^3.8.0"
+          }
+        },
+        "npm-registry-fetch": {
+          "version": "3.8.0",
+          "bundled": true,
+          "requires": {
+            "JSONStream": "^1.3.4",
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.4.1",
+            "lru-cache": "^4.1.3",
+            "make-fetch-happen": "^4.0.1",
+            "npm-package-arg": "^6.1.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "npm-user-validate": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "opener": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
+          }
+        },
+        "pacote": {
+          "version": "9.4.0",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.5.3",
+            "cacache": "^11.3.2",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.1.0",
+            "glob": "^7.1.3",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^4.0.1",
+            "minimatch": "^3.0.4",
+            "minipass": "^2.3.5",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-packlist": "^1.1.12",
+            "npm-pick-manifest": "^2.2.3",
+            "npm-registry-fetch": "^3.8.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.1",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.2",
+            "semver": "^5.6.0",
+            "ssri": "^6.0.1",
+            "tar": "^4.4.8",
+            "unique-filename": "^1.1.1",
+            "which": "^1.3.1"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "5.1.1",
+              "bundled": true,
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "parallel-transform": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "promise-retry": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "err-code": "^1.0.0",
+            "retry": "^0.10.0"
+          },
+          "dependencies": {
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true
+            }
+          }
+        },
+        "promzard": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "read": "1"
+          }
+        },
+        "proto-list": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "protoduck": {
+          "version": "5.0.1",
+          "bundled": true,
+          "requires": {
+            "genfun": "^5.0.0"
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "psl": {
+          "version": "1.1.29",
+          "bundled": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qrcode-terminal": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "6.2.0",
+          "bundled": true,
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        },
+        "qw": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "read": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "mute-stream": "~0.0.4"
+          }
+        },
+        "read-cmd-shim": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2"
+          }
+        },
+        "read-installed": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
+          }
+        },
+        "read-package-json": {
+          "version": "2.0.13",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "json-parse-better-errors": "^1.0.1",
+            "normalize-package-data": "^2.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "read-package-tree": {
+          "version": "5.2.1",
+          "bundled": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "once": "^1.3.0",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "readdir-scoped-modules": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
+          }
+        },
+        "registry-auth-token": {
+          "version": "3.3.2",
+          "bundled": true,
+          "requires": {
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "rc": "^1.0.1"
+          }
+        },
+        "request": {
+          "version": "2.88.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "retry": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "run-queue": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "semver": "^5.0.3"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "sha": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "readable-stream": "^2.0.2"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "smart-buffer": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "socks": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "ip": "^1.1.5",
+            "smart-buffer": "^4.0.1"
+          }
+        },
+        "socks-proxy-agent": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "agent-base": "~4.2.0",
+            "socks": "~2.2.0"
+          }
+        },
+        "sorted-object": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "sorted-union-stream": {
+          "version": "2.1.3",
+          "bundled": true,
+          "requires": {
+            "from2": "^1.3.0",
+            "stream-iterate": "^1.1.0"
+          },
+          "dependencies": {
+            "from2": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.3",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.14.2",
+          "bundled": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "ssri": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1"
+          }
+        },
+        "stream-each": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "stream-iterate": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "stringify-package": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          },
+          "dependencies": {
+            "chownr": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "execa": "^0.7.0"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "tiny-relative-date": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "bundled": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "umask": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "unique-filename": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "unique-slug": "^2.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "crypto-random-string": "^1.0.0"
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "update-notifier": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "util-extend": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "builtins": "^1.0.3"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "wcwidth": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "defaults": "^1.0.3"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "widest-line": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          }
+        },
+        "worker-farm": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "errno": "~0.1.7"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write-file-atomic": {
+          "version": "2.4.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "11.0.0",
+          "bundled": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
       }
     },
     "npm-run-path": {
@@ -3995,7 +7025,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "nth-check": {
@@ -4003,7 +7033,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "number-is-nan": {
@@ -4041,7 +7071,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -4049,8 +7079,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "os-browserify": {
@@ -4065,9 +7095,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "p-finally": {
@@ -4082,7 +7112,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -4091,7 +7121,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -4112,7 +7142,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "parents": {
@@ -4121,7 +7151,7 @@
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true,
       "requires": {
-        "path-platform": "0.11.15"
+        "path-platform": "~0.11.15"
       }
     },
     "parse-asn1": {
@@ -4130,11 +7160,11 @@
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.16"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-json": {
@@ -4143,7 +7173,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parseurl": {
@@ -4157,8 +7187,8 @@
       "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.0",
-        "upper-case-first": "1.1.2"
+        "camel-case": "^3.0.0",
+        "upper-case-first": "^1.1.0"
       }
     },
     "path-browserify": {
@@ -4173,7 +7203,7 @@
       "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "path-exists": {
@@ -4216,7 +7246,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
     },
     "pbkdf2": {
@@ -4225,11 +7255,11 @@
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
@@ -4259,7 +7289,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -4280,11 +7310,11 @@
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "punycode": {
@@ -4321,7 +7351,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -4330,8 +7360,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.2"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -4356,7 +7386,7 @@
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.2"
       }
     },
     "read-pkg": {
@@ -4365,9 +7395,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -4376,8 +7406,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -4385,13 +7415,13 @@
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "regexp-clone": {
@@ -4404,26 +7434,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.1.0",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.20",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "request-promise-core": {
@@ -4431,7 +7461,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.13.1"
       }
     },
     "request-promise-native": {
@@ -4440,8 +7470,8 @@
       "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.4.3"
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "require-directory": {
@@ -4461,8 +7491,8 @@
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
       "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.5.1"
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
       }
     },
     "resolve": {
@@ -4471,7 +7501,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -4485,8 +7515,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "safe-buffer": {
@@ -4516,18 +7546,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "statuses": {
@@ -4543,8 +7573,8 @@
       "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case-first": "1.1.2"
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
       }
     },
     "serve-static": {
@@ -4552,9 +7582,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -4575,8 +7605,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shasum": {
@@ -4585,8 +7615,8 @@
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.11"
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
       }
     },
     "shebang-command": {
@@ -4595,7 +7625,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -4610,10 +7640,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "signal-exit": {
@@ -4639,7 +7669,7 @@
       "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "source-map": {
@@ -4652,8 +7682,8 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
       "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
       "requires": {
-        "buffer-from": "1.1.1",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "spdx-correct": {
@@ -4662,8 +7692,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -4678,8 +7708,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -4699,15 +7729,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "statuses": {
@@ -4726,8 +7756,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-combiner2": {
@@ -4736,8 +7766,8 @@
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.6"
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-http": {
@@ -4746,11 +7776,11 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-splicer": {
@@ -4759,8 +7789,8 @@
       "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "streamsearch": {
@@ -4774,8 +7804,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4796,7 +7826,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -4806,7 +7836,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -4815,7 +7845,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -4836,7 +7866,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -4852,11 +7882,11 @@
       "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.14.tgz",
       "integrity": "sha512-n1+mgupVdJn1MIls1ZhSJurJjc+islp7Tv9EIaEJ3HAd9DaINneKq0KRqOYNOrvUI7orVWGomEnlIxoudjfbeA==",
       "requires": {
-        "backo2": "1.0.2",
-        "eventemitter3": "3.1.0",
-        "iterall": "1.2.2",
-        "symbol-observable": "1.2.0",
-        "ws": "5.2.2"
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0"
       },
       "dependencies": {
         "iterall": {
@@ -4869,7 +7899,7 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
           "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
           "requires": {
-            "async-limiter": "1.0.0"
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -4880,16 +7910,16 @@
       "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.2",
-        "debug": "3.2.5",
-        "extend": "3.0.2",
-        "form-data": "2.3.2",
-        "formidable": "1.2.1",
-        "methods": "1.1.2",
-        "mime": "1.4.1",
-        "qs": "6.5.2",
-        "readable-stream": "2.3.6"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
       },
       "dependencies": {
         "debug": {
@@ -4898,7 +7928,7 @@
           "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -4915,8 +7945,8 @@
       "integrity": "sha512-dMQSzYdaZRSANH5LL8kX3UpgK9G1LRh/jnggs/TI0W2Sz7rkMx9Y48uia3K9NgcaWEV28tYkBnXE4tiFC77ygQ==",
       "dev": true,
       "requires": {
-        "methods": "1.1.2",
-        "superagent": "3.8.3"
+        "methods": "^1.1.2",
+        "superagent": "^3.8.3"
       }
     },
     "supports-color": {
@@ -4924,7 +7954,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "swap-case": {
@@ -4933,8 +7963,8 @@
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4",
-        "upper-case": "1.1.3"
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
       }
     },
     "sweetalert2": {
@@ -4953,7 +7983,7 @@
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.5.2"
+        "acorn-node": "^1.2.0"
       }
     },
     "tabbable": {
@@ -4973,8 +8003,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "timers-browserify": {
@@ -4983,7 +8013,7 @@
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
-        "process": "0.11.10"
+        "process": "~0.11.0"
       }
     },
     "title-case": {
@@ -4992,8 +8022,8 @@
       "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
       }
     },
     "to-arraybuffer": {
@@ -5007,8 +8037,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "psl": "1.1.29",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       }
     },
     "tty-browserify": {
@@ -5022,7 +8052,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -5043,7 +8073,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.20"
+        "mime-types": "~2.1.18"
       }
     },
     "typedarray": {
@@ -5063,8 +8093,8 @@
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "optional": true,
       "requires": {
-        "commander": "2.17.1",
-        "source-map": "0.6.1"
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
       }
     },
     "ultron": {
@@ -5084,10 +8114,10 @@
       "integrity": "sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.5.2",
-        "get-assigned-identifiers": "1.2.0",
-        "simple-concat": "1.0.0",
-        "xtend": "4.0.1"
+        "acorn-node": "^1.3.0",
+        "get-assigned-identifiers": "^1.2.0",
+        "simple-concat": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "unpipe": {
@@ -5107,7 +8137,7 @@
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "dev": true,
       "requires": {
-        "upper-case": "1.1.3"
+        "upper-case": "^1.1.1"
       }
     },
     "url": {
@@ -5158,8 +8188,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {
@@ -5172,9 +8202,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -5198,7 +8228,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -5218,8 +8248,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "string-width": {
@@ -5228,9 +8258,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -5246,9 +8276,9 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.2",
-        "ultron": "1.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "xtend": {
@@ -5274,19 +8304,19 @@
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.3",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
       }
     },
     "yargs-parser": {
@@ -5295,7 +8325,7 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       }
     },
     "zen-observable": {
@@ -5308,7 +8338,7 @@
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.9.tgz",
       "integrity": "sha512-KJz2O8FxbAdAU5CSc8qZ1K2WYEJb1HxS6XDRF+hOJ1rOYcg6eTMmS9xYHCXzqZZzKw6BbXWyF4UpwSsBQnHJeA==",
       "requires": {
-        "zen-observable": "0.8.9"
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkin2",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "Check-in for HackGT events",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkin2",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Check-in for HackGT events",
   "main": "app.js",
   "scripts": {
@@ -40,6 +40,7 @@
     "mongoose": "^5.2.14",
     "morgan": "^1.9.0",
     "multer": "^1.3.0",
+    "npm": "^6.7.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "serve-static": "^1.12.1",

--- a/server/app.ts
+++ b/server/app.ts
@@ -163,7 +163,8 @@ export function printHackGTMetricsEvent(args: {user: string, tag: string}, userI
 	if (!(await Tag.findOne())) {
 		// Add default tag
 		let defaultTag = new Tag({
-			name: "hackgt"
+			name: "hackgt",
+			warnOnDuplicates: true
 		});
 		await defaultTag.save();
 	}

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -243,9 +243,7 @@ function resolver(registration: Registration): IResolver {
                 }
 
                 // If warnOnDuplicates is not set for this tag, set it to true (most restrictive option)
-                if (!tagDetails.hasOwnProperty("warnOnDuplicates")
-                    || tagDetails.warnOnDuplicates === null
-                    || typeof tagDetails.warnOnDuplicates === "undefined") {
+                if (!tagDetails.warnOnDuplicates) {
                     tagDetails.warnOnDuplicates = true;
                     await tagDetails.save();
                 }
@@ -328,9 +326,7 @@ function resolver(registration: Registration): IResolver {
                 }
 
                 // If warnOnDuplicates is not set for this tag, set it to true (most restrictive option)
-                if (!tagDetails.hasOwnProperty("warnOnDuplicates")
-                    || tagDetails.warnOnDuplicates === null
-                    || typeof tagDetails.warnOnDuplicates === "undefined") {
+                if (!tagDetails.warnOnDuplicates) {
                     tagDetails.warnOnDuplicates = true;
                     await tagDetails.save();
                 }

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -242,6 +242,14 @@ function resolver(registration: Registration): IResolver {
                     return null;
                 }
 
+                // If warnOnDuplicates is not set for this tag, set it to true (most restrictive option)
+                if (!tagDetails.hasOwnProperty("warnOnDuplicates")
+                    || tagDetails.warnOnDuplicates === null
+                    || typeof tagDetails.warnOnDuplicates === "undefined") {
+                    tagDetails.warnOnDuplicates = true;
+                    await tagDetails.save();
+                }
+
                 let attendee = await Attendee.findOne({
                     id: args.user
                 });
@@ -317,6 +325,14 @@ function resolver(registration: Registration): IResolver {
                 const tagDetails = await Tag.findOne({ name: args.tag });
                 if (!tagDetails || !schema) {
                     return null;
+                }
+
+                // If warnOnDuplicates is not set for this tag, set it to true (most restrictive option)
+                if (!tagDetails.hasOwnProperty("warnOnDuplicates")
+                    || tagDetails.warnOnDuplicates === null
+                    || typeof tagDetails.warnOnDuplicates === "undefined") {
+                    tagDetails.warnOnDuplicates = true;
+                    await tagDetails.save();
                 }
 
                 let attendee = await Attendee.findOne({

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -205,11 +205,13 @@ function resolver(registration: Registration): IResolver {
                 return Object.keys(attendee.tags).map(tag => {
                     const date = attendee.tags[tag].checked_in_date;
                     const lastSuccess = attendee.tags[tag].last_successful_checkin;
+
                     return {
                         tag: {
                             name: tag
                         },
-                        checkin_success: attendee.tags[tag].checkin_success,
+                        checkin_success: (attendee.tags[tag].checkin_success == null)
+                            ? true : attendee.tags[tag].checkin_success,
                         checked_in: attendee.tags[tag].checked_in,
                         checked_in_date: date ? date.toISOString() : "",
                         checked_in_by: attendee.tags[tag].checked_in_by || "",
@@ -217,14 +219,14 @@ function resolver(registration: Registration): IResolver {
                             checked_in: lastSuccess.checked_in,
                             checked_in_date: lastSuccess.checked_in_date.toISOString(),
                             checked_in_by: lastSuccess.checked_in_by,
-                            checkin_success: lastSuccess.checkin_success
+                            checkin_success: (lastSuccess.checkin_success == null) ? true : lastSuccess.checkin_success
                         } : null,
                         details: attendee.tags[tag].details.map((elem) => {
                             return {
                                 checked_in: elem.checked_in,
                                 checked_in_date: elem.checked_in_date.toISOString(),
                                 checked_in_by: elem.checked_in_by,
-                                checkin_success: elem.checkin_success
+                                checkin_success: (elem.checkin_success == null) ? true : elem.checkin_success
                             }
                         })
                     };
@@ -233,11 +235,11 @@ function resolver(registration: Registration): IResolver {
         },
         Mutation: {
             /**
-             * Check in a user by specifying the tag name
+             * Check in/out a user by specifying the tag name
              */
             check_in: async (prev, args, ctx, schema) => {
                 // Return none if tag doesn't exist
-                const tagDetails = await Tag.findOne({ name: args.tag });
+                const tagDetails = await Tag.findOne({name: args.tag});
                 if (!tagDetails || !schema) {
                     return null;
                 }
@@ -252,8 +254,9 @@ function resolver(registration: Registration): IResolver {
                     id: args.user
                 });
 
+                const path = args.checkin ? "check_in" : "check_out";
                 const forwarder = registration.forward({
-                    path: "check_in.user",
+                    path: `${path}.user`,
                     include: [
                         "id",
                         "email",
@@ -282,12 +285,12 @@ function resolver(registration: Registration): IResolver {
                 const pastCheckins = attendee.tags[args.tag];
 
 
-                const validCheckin = validateCheckin(pastCheckins, true);
+                const validCheckin = validateCheckin(pastCheckins, args.checkin);
                 let success = !tagDetails.warnOnDuplicates ? true : validCheckin;
 
                 attendee.tags[args.tag] = {
                     checkin_success: success,
-                    checked_in: true,
+                    checked_in: args.checkin,
                     checked_in_date: date,
                     checked_in_by: username,
                     last_successful_checkin: null,
@@ -295,105 +298,23 @@ function resolver(registration: Registration): IResolver {
                 };
 
                 attendee.tags[args.tag].details.push({
-                    checked_in: true,
+                    checked_in: args.checkin,
                     checked_in_date: date,
                     checked_in_by: username,
                     checkin_success: success
                 });
 
                 // Make sure we include the latest details element for last_successful_checkin
-                attendee.tags[args.tag].last_successful_checkin = getLastSuccessfulCheckin(attendee.tags[args.tag], true);
+                attendee.tags[args.tag].last_successful_checkin = getLastSuccessfulCheckin(attendee.tags[args.tag], args.checkin);
 
                 attendee.markModified('tags');
                 await attendee.save();
 
-                pubsub.publish(TAG_CHANGE, {[TAG_CHANGE] : userInfo});
+                pubsub.publish(TAG_CHANGE, {[TAG_CHANGE]: userInfo});
 
                 // validCheckin indicates duplicate check in/out events regardless of warnOnDuplicates,
                 //    which means we can still get accurate metrics for tags with warnOnDuplicates = false
-                printHackGTMetricsEvent(args, userInfo, loggedInUser, true, validCheckin);
-                return userInfo;
-            },
-
-            /**
-             * Check-out a user by specifying the tag name
-             */
-            check_out: async (prev, args, ctx, schema) => {
-                // Return none if tag doesn't exist
-                const tagDetails = await Tag.findOne({ name: args.tag });
-                if (!tagDetails || !schema) {
-                    return null;
-                }
-
-                // If warnOnDuplicates is not set for this tag, set it to true (most restrictive option)
-                if (!tagDetails.warnOnDuplicates) {
-                    tagDetails.warnOnDuplicates = true;
-                    await tagDetails.save();
-                }
-
-                let attendee = await Attendee.findOne({
-                    id: args.user
-                });
-
-                const forwarder = registration.forward({
-                    path: "check_out.user",
-                    include: [
-                        "id",
-                        "email",
-                        "name"
-                    ],
-                    head: `user(id: "${args.user}")`
-                });
-                const userInfo = await forwarder(prev, args, ctx, schema);
-                if (!userInfo.user) {
-                    return null;
-                }
-
-                // Create attendee if it doesn't already exist
-                if (!attendee) {
-                    attendee = new Attendee({
-                        id: args.user,
-                        name: userInfo.user.name,
-                        emails: userInfo.user.email,
-                        tags: {}
-                    });
-                }
-                const loggedInUser = await getLoggedInUser(ctx);
-                const date = new Date();
-                const username = loggedInUser.user ? loggedInUser.user.username : "";
-                const pastCheckins = attendee.tags[args.tag];
-                const validCheckin = validateCheckin(pastCheckins, false);
-                let success = (!tagDetails.warnOnDuplicates && pastCheckins && pastCheckins.details
-                    && pastCheckins.details.length > 0) ? true : validCheckin;
-
-                attendee.tags[args.tag] = {
-                    checkin_success: success,
-                    checked_in: false,
-                    checked_in_date: date,
-                    checked_in_by: username,
-                    last_successful_checkin: null,
-                    details: attendee.tags[args.tag] ? attendee.tags[args.tag].details : []
-                };
-
-                attendee.tags[args.tag].details.push({
-                    checked_in: false,
-                    checked_in_date: date,
-                    checked_in_by: username,
-                    checkin_success: success
-                });
-
-                // Make sure we include the latest details element for last_successful_checkin
-                attendee.tags[args.tag].last_successful_checkin = getLastSuccessfulCheckin(attendee.tags[args.tag], false);
-
-
-                attendee.markModified('tags');
-                await attendee.save();
-
-                pubsub.publish(TAG_CHANGE, {[TAG_CHANGE] : userInfo});
-
-                // validCheckin indicates duplicate check in/out events regardless of warnOnDuplicates,
-                //    which means we can still get accurate metrics for tags with warnOnDuplicates = false
-                printHackGTMetricsEvent(args, userInfo, loggedInUser, false, validCheckin);
+                printHackGTMetricsEvent(args, userInfo, loggedInUser, args.checkin, validCheckin);
                 return userInfo;
             },
 

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -58,7 +58,7 @@ function getLastSuccessfulCheckin(pastCheckins: ITagItem, checkIn: boolean): ITa
     if (!pastCheckins || !pastCheckins.details) {
         return null;
     }
-    let { details } = pastCheckins; // ES6 destructuring, so this is equivalent to let details = pastCheckins.details
+    let {details} = pastCheckins; // ES6 destructuring, so this is equivalent to let details = pastCheckins.details
 
     for (let i = details.length - 1; i >= 0; i--) { // start at the end b/c later check-in/out events will be at the end of the array
         const event = details[i];
@@ -245,7 +245,9 @@ function resolver(registration: Registration): IResolver {
                 }
 
                 // If warnOnDuplicates is not set for this tag, set it to true (most restrictive option)
-                if (!tagDetails.warnOnDuplicates) {
+                // console.log here to better identify what's happening here in prod
+                console.log("tagDetails.warnOnDuplicates", tagDetails.warnOnDuplicates);
+                if (tagDetails.warnOnDuplicates == null) {
                     tagDetails.warnOnDuplicates = true;
                     await tagDetails.save();
                 }
@@ -323,11 +325,11 @@ function resolver(registration: Registration): IResolver {
              */
             add_tag: async (prev, args, ctx, schema) => {
                 // Return none if the tag already exists (prevent duplicates)
-                if (await Tag.findOne({ name: args.tag })) {
+                if (await Tag.findOne({name: args.tag})) {
                     return null;
                 }
 
-                let tag = new Tag({ name: args.tag });
+                let tag = new Tag({name: args.tag});
                 if (args.start) tag.start = new Date(args.start);
                 if (args.end) tag.end = new Date(args.end);
                 if (tag.start && tag.end && tag.start >= tag.end) {

--- a/server/graphql.ts
+++ b/server/graphql.ts
@@ -256,9 +256,8 @@ function resolver(registration: Registration): IResolver {
                     id: args.user
                 });
 
-                const path = args.checkin ? "check_in" : "check_out";
                 const forwarder = registration.forward({
-                    path: `${path}.user`,
+                    path: `check_in.user`,
                     include: [
                         "id",
                         "email",

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -101,6 +101,6 @@ export const Tag = mongoose.model<ITagMongoose>("Tag", new mongoose.Schema({
 	warnOnDuplicates: {
 		type: Boolean,
 		required: true,
-		default: false
+		default: true
 	}
 }));


### PR DESCRIPTION
**What's new:**

- Hotfix for #61
- ⚠ The `check_in` and `check_out` GraphQL mutations have been merged into one `check_in` mutation to reduce duplicated code.  Checking a user into a tag vs. checking them out can now be specified using a newly added parameter to the `check_in` mutation.  Since this is a breaking change, the version number has been incremented to 3.0.0.
- The "Checked in x minutes ago by `<user>`" message is now based on the timestamp and user of the `last_successful_checkin` property.  This prevents information from duplicate check-ins from showing up when it shouldn't (only when `warnOnDuplicates` is true for the tag in question).
- Added a new alert on the front-end (see below) to detect when local data is out-of-date because of a modification made directly in the database (or perhaps a missed websocket message).  Ideally this should be a rare occurance.
![glitch in the matrix](https://user-images.githubusercontent.com/5790137/52888166-a8264f00-3148-11e9-8537-b11fa27fbd39.png)
- The "user successfully created" and "user's password changed successfully" alerts on the Configure Users screen now wait to refresh the page until the alert box is closed
- Refactored the user delete confirmation dialog to use SweetAlert2
- The default `hackgt` tag now has `warnOnDuplicates` explicitly set to true on its creation

Closes #61 